### PR TITLE
Move primary menu to top bar and enlarge logo

### DIFF
--- a/header.php
+++ b/header.php
@@ -55,7 +55,7 @@
 
         <?php // --- Top Header Bar with Hamburger Menu --- ?>
         <div class="top-header-bar py-3" style="background-color: var(--color-header-bg);">
-            <div class="container d-flex justify-content-between align-items-center">
+            <div class="container d-flex align-items-center">
 
                 <?php // Left side: Hamburger + Logo ?>
                 <div class="d-flex align-items-center">
@@ -87,8 +87,22 @@
                     </div>
                 </div>
 
+                <div class="navbar-horizontal-menu d-none d-md-flex flex-grow-1 justify-content-center">
+                    <?php
+                    wp_nav_menu(
+                            array(
+                                    'theme_location' => 'primary',
+                                    'menu_class'     => 'navbar-nav-horizontal',
+                                    'container'      => false,
+                                    'fallback_cb'    => false,
+                                    'depth'          => 1,
+                            )
+                    );
+                    ?>
+                </div>
+
                 <?php // Right side: Contact info and CTA button ?>
-                <div class="header-top-button">
+                <div class="header-top-button ms-auto">
                     <div class="header-contact d-flex align-items-center justify-content-end">
                         <?php
                         $phone = get_theme_mod( 'header_phone_number', '941-203-1196' );
@@ -110,25 +124,6 @@
 
             </div>
         </div>
-
-        <?php // --- Main Navigation Bar (No hamburger - horizontal menu on all devices) --- ?>
-        <nav class="navbar main-navbar bg-white shadow-sm d-none d-md-block">
-            <div class="container">
-                <div class="navbar-horizontal-menu w-100">
-                    <?php
-                    wp_nav_menu(
-                            array(
-                                    'theme_location' => 'new-primary',
-                                    'menu_class'     => 'navbar-nav-horizontal',
-                                    'container'      => false,
-                                    'fallback_cb'    => false,
-                                    'depth'          => 1, // Only show top level items for mobile compatibility
-                            )
-                    );
-                    ?>
-                </div>
-            </div>
-        </nav>
 
         <?php // --- Offcanvas Menu (Triggered by hamburger in top bar) --- ?>
         <div class="offcanvas offcanvas-start dream-tails-offcanvas" tabindex="-1" id="mobileNavOffcanvas" aria-labelledby="mobileNavOffcanvasLabel">

--- a/style.css
+++ b/style.css
@@ -129,9 +129,15 @@ a:hover {
 
 /* Control Logo Size using the wrapper div */
 .top-bar-logo img { /* Target any img inside the wrapper */
-    max-height: 80px; /* Smaller logo on desktop */
     width: auto;       /* Maintain aspect ratio */
     display: block;    /* Ensure it behaves as a block element */
+}
+
+@media (min-width: 768px) {
+    .top-bar-logo img {
+        width: 300px;
+        height: auto;
+    }
 }
 
 /* Style Top Right "Book Appointment" Button */


### PR DESCRIPTION
## Summary
- Show the Primary menu in the top header bar and remove the extra navbar.
- Set the desktop logo width to 300px.

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689c0c56da088326a262b78b163c6f9e