### PR TITLE
Use Poppins font site-wide

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -166,13 +166,11 @@ function dreamtails_scripts() {
     // Font Awesome CSS (CDN)
     wp_enqueue_style( 'font-awesome', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css', array(), '6.5.2' );
 
-    // Enqueue main theme stylesheet. (Loads AFTER Bootstrap to allow overrides)
-    wp_enqueue_style( 'dreamtails-style', get_stylesheet_uri(), array('bootstrap'), DREAMTAILS_VERSION );
+    // Google Font: Poppins
+    wp_enqueue_style( 'dreamtails-google-fonts', 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap', array(), null );
 
-    // Google Fonts (Example - keep if needed)
-//     wp_enqueue_style( 'dreamtails-josefin-sans', 'https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;700&display=swap', array(), null );
-    // Local Mollie Glaston font loaded via style.css
-    // wp_enqueue_style( 'dreamtails-google-fonts', 'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Playfair+Display:wght@700&display=swap', array(), null );
+    // Enqueue main theme stylesheet. (Loads AFTER Bootstrap and Google Fonts to allow overrides)
+    wp_enqueue_style( 'dreamtails-style', get_stylesheet_uri(), array('bootstrap', 'dreamtails-google-fonts'), DREAMTAILS_VERSION );
 
     // Enqueue comment reply script (Essential for threaded comments)
     if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {

--- a/style.css
+++ b/style.css
@@ -11,15 +11,6 @@ Tags: custom-background, custom-logo, custom-menu, featured-images, theme-option
 Text Domain: dreamtails
 */
 
-@font-face {
-    font-family: "Mollie Glaston";
-    src: url("assets/fonts/mollie_glaston.otf") format("opentype"),
-    url("assets/fonts/mollie_glaston.ttf") format("truetype");
-    font-weight: normal;
-    font-style: normal;
-    font-display: swap;
-}
-
 /* --- Variables --- */
 :root {
     --color-primary-light-blue-grey: #BCC9C5; /* Primary 1 - Header/Footer BG */
@@ -46,9 +37,9 @@ Text Domain: dreamtails
     --color-link: var(--color-secondary-teal);
     --color-link-hover: var(--color-primary-dark-teal);
 
-    /* Font Families (Examples - Replace with actual choices if available) */
-    --font-primary: 'Lato', sans-serif; /* Body text */
-    --font-secondary: 'Playfair Display', serif; /* Headings */
+    /* Font Families */
+    --font-primary: 'Poppins', sans-serif; /* Body text */
+    --font-secondary: 'Poppins', sans-serif; /* Headings */
 }
 
 /* WooCommerce Blocks (Cart & Checkout) */
@@ -84,9 +75,6 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     font-family: var(--font-secondary);
     color: var(--color-heading);
     margin-top: 0;
-}
-h1, h2 {
-    font-family: "Mollie Glaston", sans-serif;
 }
 
 /* Link styling */


### PR DESCRIPTION
## Summary
- Load Google Fonts Poppins and add it as dependency of main stylesheet
- Apply Poppins as primary and secondary font variables across theme

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f301fc08326980993fcf8d67e9d