### PR TITLE
Replace DreamTails branding with Happiness Is Pets

### DIFF
--- a/404.php
+++ b/404.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying 404 pages (not found)
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 get_header();
@@ -21,7 +21,7 @@ get_header();
                 }
                 ?>
             </div>
-            <h1 class="display-5 fw-bold"><?php esc_html_e( 'We are sorry we must be dreaming, but this page cannot be found.', 'dreamtails' ); ?></h1>
+            <h1 class="display-5 fw-bold"><?php esc_html_e( 'We are sorry we must be dreaming, but this page cannot be found.', 'happiness-is-pets' ); ?></h1>
         </div>
     </div>
 </main>

--- a/footer.php
+++ b/footer.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying the footer
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 ?>
 
@@ -17,7 +17,7 @@
                         <?php the_custom_logo(); ?>
                     </div>
                 <?php endif; ?>
-                <h5 class="widget-title"><?php echo esc_html( get_theme_mod( 'footer_col1_heading', __( 'Navigation', 'dreamtails' ) ) ); ?></h5>
+                <h5 class="widget-title"><?php echo esc_html( get_theme_mod( 'footer_col1_heading', __( 'Navigation', 'happiness-is-pets' ) ) ); ?></h5>
                 <?php
                 if ( has_nav_menu( 'footer' ) ) {
                     wp_nav_menu(
@@ -36,7 +36,7 @@
                 ?>
             </div><?php // Footer Column 2: Info/Address ?>
             <div class="col-lg-3 col-md-6 footer-info">
-                <h5 class="widget-title"><?php echo esc_html( get_theme_mod( 'footer_col2_heading', __( 'Dream Tails Sarasota', 'dreamtails' ) ) ); ?></h5>
+                <h5 class="widget-title"><?php echo esc_html( get_theme_mod( 'footer_col2_heading', __( 'Happiness Is Pets Sarasota', 'happiness-is-pets' ) ) ); ?></h5>
                 <?php
                 // $part_of_the_Petland = get_theme_mod( 'footer_col2_part_of_the_petland', "Part of the Petland family of stores" );
                 $address = get_theme_mod( 'footer_col2_address', "6453 Lockwood Ridge Rd\nSarasota, FL 34243" );
@@ -56,7 +56,7 @@
                 </div>
             </div><?php // Footer Column 3: Hours ?>
             <div class="col-lg-3 col-md-6 footer-hours">
-                <h5 class="widget-title"><?php echo esc_html( get_theme_mod( 'footer_col3_heading', __( 'Store Hours', 'dreamtails' ) ) ); ?></h5>
+                <h5 class="widget-title"><?php echo esc_html( get_theme_mod( 'footer_col3_heading', __( 'Store Hours', 'happiness-is-pets' ) ) ); ?></h5>
                 <!-- <p><i class="far fa-clock me-2"></i><?php //echo nl2br( esc_html( get_theme_mod( 'footer_col3_hours', "Mon - Sat: 10am - 8pm\nSun: 11am - 7pm" ) ) ); ?></p> -->
                 <?php
 $hours = get_theme_mod(
@@ -79,10 +79,10 @@ foreach ($hours_lines as $line) {
 
             </div><?php // Footer Column 4: Extra Info ?>
             <div class="col-lg-3 col-md-6 footer-extra">
-                <!-- <h5 class="widget-title"><?php //echo esc_html( get_theme_mod( 'footer_col4_heading', __( 'About Us', 'dreamtails' ) ) ); ?></h5> -->
-                <h5 class="widget-title"><img src="<?php echo esc_url( 'https://dreamtails.kinsta.cloud/wp-content/uploads/2025/08/DreamTailsstackedlogo-04-1.png' ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?> stacked logo" loading="lazy" /></h5>
-                <!-- <p><?php //echo esc_html( get_theme_mod( 'footer_col4_text', __( 'Part of the Petland family of stores.', 'dreamtails' ) ) ); ?></p> -->
-                <p><?php echo esc_html( get_theme_mod( 'footer_col4_heading', __( 'Part of the Petland family of stores.', 'dreamtails' ) ) ); ?></p>
+                <!-- <h5 class="widget-title"><?php //echo esc_html( get_theme_mod( 'footer_col4_heading', __( 'About Us', 'happiness-is-pets' ) ) ); ?></h5> -->
+                <h5 class="widget-title"><img src="<?php echo esc_url( 'https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/08/happiness-is-pets-stackedlogo-04-1.png' ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?> stacked logo" loading="lazy" /></h5>
+                <!-- <p><?php //echo esc_html( get_theme_mod( 'footer_col4_text', __( 'Part of the Petland family of stores.', 'happiness-is-pets' ) ) ); ?></p> -->
+                <p><?php echo esc_html( get_theme_mod( 'footer_col4_heading', __( 'Part of the Petland family of stores.', 'happiness-is-pets' ) ) ); ?></p>
                 
                 <!-- <div>
                     <a href="<?php //echo esc_url( get_theme_mod( 'footer_facebook_url', '#' ) ); ?>" class="me-2"><i class="fab fa-facebook-f"></i></a>
@@ -91,8 +91,8 @@ foreach ($hours_lines as $line) {
             </div></div><hr class="mt-4 mb-3" style="border-color: rgba(255, 255, 255, 0.2);">
 
         <div class="footer-bottom text-center">
-            <p class="mb-1">&copy; <?php echo esc_html( date_i18n( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>. <?php esc_html_e( 'All Rights Reserved.', 'dreamtails' ); ?></p>
-            <p class="mb-0 small"><?php esc_html_e( 'Developed by', 'dreamtails' ); ?> <a href="https://cosmickmedia.com/" target="_blank" rel="noopener">Cosmick Media</a></p>
+            <p class="mb-1">&copy; <?php echo esc_html( date_i18n( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>. <?php esc_html_e( 'All Rights Reserved.', 'happiness-is-pets' ); ?></p>
+            <p class="mb-0 small"><?php esc_html_e( 'Developed by', 'happiness-is-pets' ); ?> <a href="https://cosmickmedia.com/" target="_blank" rel="noopener">Cosmick Media</a></p>
         </div></div></footer></div><?php wp_footer(); ?>
 
 </body>

--- a/front-page.php
+++ b/front-page.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying the static front page.
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 get_header();
@@ -18,12 +18,12 @@ get_header();
                 <div class="col-md-6">
                     <div class="hero-content bg-light bg-opacity-75 p-4 p-md-5 rounded text-center">
                         <h1 class="display-4" style="color: var(--color-primary-dark-teal);">
-                            <?php echo esc_html( get_theme_mod( 'front_hero_heading', __( 'where pets find their people', 'dreamtails' ) ) ); ?>
+                            <?php echo esc_html( get_theme_mod( 'front_hero_heading', __( 'where pets find their people', 'happiness-is-pets' ) ) ); ?>
                         </h1>
                         <?php $hero_url = get_theme_mod( 'header_book_button_url', '' ); ?>
                         <?php if ( $hero_url ) : ?>
                             <a href="<?php echo esc_url( $hero_url ); ?>" class="btn btn-lg mt-3 btn-book-appointment d-inline-flex align-items-center mt-2" style="background-color: var(--color-button); color: var(--color-button-text);">
-                                <i class="fa-regular fa-calendar-check me-2"></i> <?php echo esc_html( get_theme_mod( 'front_hero_button_text', __( 'Book an Appointment', 'dreamtails' ) ) ); ?>
+                                <i class="fa-regular fa-calendar-check me-2"></i> <?php echo esc_html( get_theme_mod( 'front_hero_button_text', __( 'Book an Appointment', 'happiness-is-pets' ) ) ); ?>
                             </a>
                         <?php endif; ?>
                     </div>
@@ -38,20 +38,20 @@ get_header();
             <div class="row text-center gy-4">
                 <div class="col-md-4 icon-item">
                     <a href="<?php echo esc_url( get_theme_mod( 'front_icon1_link', '#' ) ); ?>" class="text-decoration-none d-block">
-                        <img src="<?php echo esc_url( get_theme_mod( 'front_icon1_img', get_template_directory_uri() . '/assets/images/puppy_ico.png' ) ); ?>" alt="<?php esc_attr_e( 'Puppy icon', 'dreamtails' ); ?>" class="mb-3" />
-                        <p class="fw-bold mb-0"><?php echo esc_html( get_theme_mod( 'front_icon1_text', __( 'puppies dreaming of you', 'dreamtails' ) ) ); ?></p>
+                        <img src="<?php echo esc_url( get_theme_mod( 'front_icon1_img', get_template_directory_uri() . '/assets/images/puppy_ico.png' ) ); ?>" alt="<?php esc_attr_e( 'Puppy icon', 'happiness-is-pets' ); ?>" class="mb-3" />
+                        <p class="fw-bold mb-0"><?php echo esc_html( get_theme_mod( 'front_icon1_text', __( 'puppies dreaming of you', 'happiness-is-pets' ) ) ); ?></p>
                     </a>
                 </div>
                 <div class="col-md-4 icon-item">
                     <a href="<?php echo esc_url( get_theme_mod( 'front_icon2_link', '#' ) ); ?>" class="text-decoration-none d-block">
-                        <img src="<?php echo esc_url( get_theme_mod( 'front_icon2_img', get_template_directory_uri() . '/assets/images/kittens_ico.png' ) ); ?>" alt="<?php esc_attr_e( 'Kitten icon', 'dreamtails' ); ?>" class="mb-3" />
-                        <p class="fw-bold mb-0"><?php echo esc_html( get_theme_mod( 'front_icon2_text', __( 'kittens dreaming of you', 'dreamtails' ) ) ); ?></p>
+                        <img src="<?php echo esc_url( get_theme_mod( 'front_icon2_img', get_template_directory_uri() . '/assets/images/kittens_ico.png' ) ); ?>" alt="<?php esc_attr_e( 'Kitten icon', 'happiness-is-pets' ); ?>" class="mb-3" />
+                        <p class="fw-bold mb-0"><?php echo esc_html( get_theme_mod( 'front_icon2_text', __( 'kittens dreaming of you', 'happiness-is-pets' ) ) ); ?></p>
                     </a>
                 </div>
                 <div class="col-md-4 icon-item">
                     <a href="<?php echo esc_url( get_theme_mod( 'front_icon3_link', '#' ) ); ?>" class="text-decoration-none d-block">
-                        <img src="<?php echo esc_url( get_theme_mod( 'front_icon3_img', get_template_directory_uri() . '/assets/images/concierge.png' ) ); ?>" alt="<?php esc_attr_e( 'Concierge icon', 'dreamtails' ); ?>" class="mb-3" />
-                        <p class="fw-bold mb-0"><?php echo esc_html( get_theme_mod( 'front_icon3_text', __( 'concierge service', 'dreamtails' ) ) ); ?></p>
+                        <img src="<?php echo esc_url( get_theme_mod( 'front_icon3_img', get_template_directory_uri() . '/assets/images/concierge.png' ) ); ?>" alt="<?php esc_attr_e( 'Concierge icon', 'happiness-is-pets' ); ?>" class="mb-3" />
+                        <p class="fw-bold mb-0"><?php echo esc_html( get_theme_mod( 'front_icon3_text', __( 'concierge service', 'happiness-is-pets' ) ) ); ?></p>
                     </a>
                 </div>
             </div>
@@ -62,7 +62,7 @@ get_header();
     <section class="front-page-section py-5 bg-light mb-5" id="featured-pets">
         <div class="container">
             <h2 class="section-title text-center mb-4">
-                <?php echo esc_html( get_theme_mod( 'front_featured_pets_heading', __( 'featured dream pets', 'dreamtails' ) ) ); ?>
+                <?php echo esc_html( get_theme_mod( 'front_featured_pets_heading', __( 'featured dream pets', 'happiness-is-pets' ) ) ); ?>
             </h2>
             <div class="row featured-pets-row align-items-center">
                 <div class="col-12 col-md-9">
@@ -77,7 +77,7 @@ get_header();
                                 <?php if ( $link ) : ?>
                                     <a href="<?php echo esc_url( $link ); ?>">
                                 <?php endif; ?>
-                                <img src="<?php echo esc_url( $image ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Featured Pet %d', 'dreamtails' ), $i ) ); ?>" class="img-fluid">
+                                <img src="<?php echo esc_url( $image ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Featured Pet %d', 'happiness-is-pets' ), $i ) ); ?>" class="img-fluid">
                                 <?php if ( $link ) : ?>
                                     </a>
                                 <?php endif; ?>
@@ -88,7 +88,7 @@ get_header();
                 </div>
                 <div class="col-12 col-md-3 text-md-start text-center mt-3 mt-md-0 d-flex align-items-center justify-content-center">
                     <a href="/all-pets/" class="view-all-pets-link d-inline-flex align-items-center">
-                        <span class="me-2"><?php esc_html_e('View all Dream Pets', 'dreamtails'); ?></span>
+                        <span class="me-2"><?php esc_html_e('View all Dream Pets', 'happiness-is-pets'); ?></span>
                         <i class="fas fa-arrow-right"></i>
                     </a>
                 </div>
@@ -100,7 +100,7 @@ get_header();
 <section class="front-page-section py-5 mb-5" id="happy-tails">
     <div class="container">
         <h2 class="section-title text-center mb-5">
-            <?php echo esc_html( get_theme_mod( 'front_testimonial_heading', __( 'happy tails start here', 'dreamtails' ) ) ); ?>
+            <?php echo esc_html( get_theme_mod( 'front_testimonial_heading', __( 'happy tails start here', 'happiness-is-pets' ) ) ); ?>
         </h2>
 
         <?php
@@ -114,7 +114,7 @@ get_header();
             <div class="swiper testimonial-swiper">
                 <div class="swiper-wrapper">
                     <?php while ( $review_query->have_posts() ) : $review_query->the_post();
-                        $rating = intval( get_post_meta( get_the_ID(), '_dreamtails_review_rating', true ) );
+                        $rating = intval( get_post_meta( get_the_ID(), '_happiness_is_pets_review_rating', true ) );
                     ?>
                         <div class="swiper-slide">
                             <div class="text-center testimonial-content px-4">
@@ -141,7 +141,7 @@ get_header();
         <?php endif; ?>
     </div>
 
-    <img class="testimonial-decor" src="<?php echo esc_url( get_theme_mod( 'front_testimonial_image', get_template_directory_uri() . '/assets/images/reviews-image.png' ) ); ?>" alt="<?php esc_attr_e( 'Testimonial image', 'dreamtails' ); ?>" />
+    <img class="testimonial-decor" src="<?php echo esc_url( get_theme_mod( 'front_testimonial_image', get_template_directory_uri() . '/assets/images/reviews-image.png' ) ); ?>" alt="<?php esc_attr_e( 'Testimonial image', 'happiness-is-pets' ); ?>" />
 </section>
 
 <!-- Swiper Init Script -->
@@ -168,13 +168,13 @@ get_header();
     <section class="front-page-section py-5 bg-light mb-5" id="concierge-care">
         <div class="container text-center">
             <h2 class="section-title text-center mb-5">
-                <?php echo esc_html( get_theme_mod( 'front_concierge_heading', __( 'concierge level care', 'dreamtails' ) ) ); ?>
+                <?php echo esc_html( get_theme_mod( 'front_concierge_heading', __( 'concierge level care', 'happiness-is-pets' ) ) ); ?>
             </h2>
             <div class="concierge-care-content mx-auto">
-                <p class="lead"><?php echo esc_html( get_theme_mod( 'front_concierge_lead', __( 'Our service and environment are designed to match the high quality of puppies and kittens in our store and meet your expectations.', 'dreamtails' ) ) ); ?></p>
-                <p><?php echo esc_html( get_theme_mod( 'front_concierge_desc', __( 'We think the puppies and kittens are worth it and so are you!', 'dreamtails' ) ) ); ?></p>
+                <p class="lead"><?php echo esc_html( get_theme_mod( 'front_concierge_lead', __( 'Our service and environment are designed to match the high quality of puppies and kittens in our store and meet your expectations.', 'happiness-is-pets' ) ) ); ?></p>
+                <p><?php echo esc_html( get_theme_mod( 'front_concierge_desc', __( 'We think the puppies and kittens are worth it and so are you!', 'happiness-is-pets' ) ) ); ?></p>
                 <a href="<?php echo esc_url( get_theme_mod( 'front_concierge_button_url', '/about/' ) ); ?>" class="btn mt-3" style="background-color: var(--color-button); color: var(--color-button-text);">
-                    <i class="fas fa-info-circle me-1"></i> <?php echo esc_html( get_theme_mod( 'front_concierge_button_text', __( 'Learn more about Dream Tails Boutique', 'dreamtails' ) ) ); ?>
+                    <i class="fas fa-info-circle me-1"></i> <?php echo esc_html( get_theme_mod( 'front_concierge_button_text', __( 'Learn more about Happiness Is Pets Boutique', 'happiness-is-pets' ) ) ); ?>
                 </a>
             </div>
         </div>

--- a/functions.php
+++ b/functions.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Dream Tails functions and definitions
+ * Happiness Is Pets functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
-if ( ! defined( 'DREAMTAILS_VERSION' ) ) {
+if ( ! defined( 'HAPPINESS_IS_PETS_VERSION' ) ) {
     // Replace the version number of the theme on each release.
-    define( 'DREAMTAILS_VERSION', '1.1' ); // Updated version
+    define( 'HAPPINESS_IS_PETS_VERSION', '1.1' ); // Updated version
 }
 
 /**
@@ -26,7 +26,7 @@ function is_catalog_mode() {
 /**
  * Output breadcrumbs with YoastSEO support.
  */
-function dreamtails_breadcrumb() {
+function happiness_is_pets_breadcrumb() {
     if ( function_exists( 'yoast_breadcrumb' ) ) {
         yoast_breadcrumb( '<nav class="breadcrumb-wrapper mb-3">', '</nav>' );
     } elseif ( function_exists( 'woocommerce_breadcrumb' ) ) {
@@ -37,9 +37,9 @@ function dreamtails_breadcrumb() {
 /**
  * Sets up theme defaults and registers support for various WordPress features.
  */
-function dreamtails_setup() {
+function happiness_is_pets_setup() {
     // Make theme available for translation.
-    load_theme_textdomain( 'dreamtails', get_template_directory() . '/languages' );
+    load_theme_textdomain( 'happiness-is-pets', get_template_directory() . '/languages' );
 
     // Add default posts and comments RSS feed links to head.
     add_theme_support( 'automatic-feed-links' );
@@ -53,10 +53,10 @@ function dreamtails_setup() {
     // Register navigation menus.
     register_nav_menus(
             array(
-                    'primary' => esc_html__( 'Primary Menu', 'dreamtails' ),
-                    'footer'  => esc_html__( 'Footer Menu', 'dreamtails' ),
-                    'new-primary'  => esc_html__( 'New Primary Menu', 'dreamtails' ),
-                    'admin'  => esc_html__( 'Admin', 'dreamtails' ),
+                    'primary' => esc_html__( 'Primary Menu', 'happiness-is-pets' ),
+                    'footer'  => esc_html__( 'Footer Menu', 'happiness-is-pets' ),
+                    'new-primary'  => esc_html__( 'New Primary Menu', 'happiness-is-pets' ),
+                    'admin'  => esc_html__( 'Admin', 'happiness-is-pets' ),
             )
     );
 
@@ -105,19 +105,19 @@ function dreamtails_setup() {
     add_theme_support( 'custom-units' );
     add_theme_support( 'editor-font-sizes', array(
             array(
-                    'name'      => __( 'Small', 'dreamtails' ),
+                    'name'      => __( 'Small', 'happiness-is-pets' ),
                     'shortName' => 'S',
                     'size'      => 14,
                     'slug'      => 'small',
             ),
             array(
-                    'name'      => __( 'Normal', 'dreamtails' ),
+                    'name'      => __( 'Normal', 'happiness-is-pets' ),
                     'shortName' => 'M',
                     'size'      => 18,
                     'slug'      => 'normal',
             ),
             array(
-                    'name'      => __( 'Large', 'dreamtails' ),
+                    'name'      => __( 'Large', 'happiness-is-pets' ),
                     'shortName' => 'L',
                     'size'      => 24,
                     'slug'      => 'large',
@@ -125,17 +125,17 @@ function dreamtails_setup() {
     ) );
     add_theme_support( 'editor-color-palette', array(
             array(
-                    'name'  => __( 'Primary', 'dreamtails' ),
+                    'name'  => __( 'Primary', 'happiness-is-pets' ),
                     'slug'  => 'primary',
                     'color' => '#3D5155',
             ),
             array(
-                    'name'  => __( 'Accent', 'dreamtails' ),
+                    'name'  => __( 'Accent', 'happiness-is-pets' ),
                     'slug'  => 'accent',
                     'color' => '#F1E6B2',
             ),
             array(
-                    'name'  => __( 'Secondary', 'dreamtails' ),
+                    'name'  => __( 'Secondary', 'happiness-is-pets' ),
                     'slug'  => 'secondary',
                     'color' => '#F7BCAC',
             ),
@@ -154,12 +154,12 @@ function dreamtails_setup() {
     add_theme_support( 'yoast-seo-breadcrumbs' );
 
 }
-add_action( 'after_setup_theme', 'dreamtails_setup' );
+add_action( 'after_setup_theme', 'happiness_is_pets_setup' );
 
 /**
  * Enqueue scripts and styles.
  */
-function dreamtails_scripts() {
+function happiness_is_pets_scripts() {
     // Bootstrap CSS (CDN)
     wp_enqueue_style( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css', array(), '5.3.3' );
 
@@ -167,10 +167,10 @@ function dreamtails_scripts() {
     wp_enqueue_style( 'font-awesome', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css', array(), '6.5.2' );
 
     // Google Font: Poppins
-    wp_enqueue_style( 'dreamtails-google-fonts', 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap', array(), null );
+    wp_enqueue_style( 'happiness-is-pets-google-fonts', 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap', array(), null );
 
     // Enqueue main theme stylesheet. (Loads AFTER Bootstrap and Google Fonts to allow overrides)
-    wp_enqueue_style( 'dreamtails-style', get_stylesheet_uri(), array('bootstrap', 'dreamtails-google-fonts'), DREAMTAILS_VERSION );
+    wp_enqueue_style( 'happiness-is-pets-style', get_stylesheet_uri(), array('bootstrap', 'happiness-is-pets-google-fonts'), HAPPINESS_IS_PETS_VERSION );
 
     // Enqueue comment reply script (Essential for threaded comments)
     if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
@@ -181,22 +181,22 @@ function dreamtails_scripts() {
     wp_enqueue_script( 'bootstrap-bundle', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js', array(), '5.3.3', true );
 
     // Custom JS for theme interactions (e.g., mobile menu if not using Bootstrap's data attributes alone)
-    // wp_enqueue_script( 'dreamtails-custom', get_template_directory_uri() . '/assets/js/custom.js', array('jquery', 'bootstrap-bundle'), DREAMTAILS_VERSION, true );
+    // wp_enqueue_script( 'happiness-is-pets-custom', get_template_directory_uri() . '/assets/js/custom.js', array('jquery', 'bootstrap-bundle'), HAPPINESS_IS_PETS_VERSION, true );
 
 }
-add_action( 'wp_enqueue_scripts', 'dreamtails_scripts' );
+add_action( 'wp_enqueue_scripts', 'happiness_is_pets_scripts' );
 
 
 /**
  * Register widget area.
  */
-function dreamtails_widgets_init() {
+function happiness_is_pets_widgets_init() {
     // Footer Widget Areas (Using Bootstrap column classes)
     register_sidebar(
             array(
-                    'name'          => esc_html__( 'Footer Column 1', 'dreamtails' ),
+                    'name'          => esc_html__( 'Footer Column 1', 'happiness-is-pets' ),
                     'id'            => 'footer-1',
-                    'description'   => esc_html__( 'Add widgets here for the first footer column.', 'dreamtails' ),
+                    'description'   => esc_html__( 'Add widgets here for the first footer column.', 'happiness-is-pets' ),
                     'before_widget' => '<div id="%1$s" class="widget %2$s">', // Removed default section tag
                     'after_widget'  => '</div>',
                     'before_title'  => '<h5 class="widget-title">', // Use h5 for footer widget titles
@@ -205,9 +205,9 @@ function dreamtails_widgets_init() {
     );
     register_sidebar(
             array(
-                    'name'          => esc_html__( 'Footer Column 2 (Info)', 'dreamtails' ),
+                    'name'          => esc_html__( 'Footer Column 2 (Info)', 'happiness-is-pets' ),
                     'id'            => 'footer-2',
-                    'description'   => esc_html__( 'Add widgets here for the second footer column (e.g., address, hours).', 'dreamtails' ),
+                    'description'   => esc_html__( 'Add widgets here for the second footer column (e.g., address, hours).', 'happiness-is-pets' ),
                     'before_widget' => '<div id="%1$s" class="widget %2$s footer-info">',
                     'after_widget'  => '</div>',
                     'before_title'  => '<h5 class="widget-title">',
@@ -216,9 +216,9 @@ function dreamtails_widgets_init() {
     );
     register_sidebar(
             array(
-                    'name'          => esc_html__( 'Footer Column 3', 'dreamtails' ),
+                    'name'          => esc_html__( 'Footer Column 3', 'happiness-is-pets' ),
                     'id'            => 'footer-3',
-                    'description'   => esc_html__( 'Add widgets here for the third footer column.', 'dreamtails' ),
+                    'description'   => esc_html__( 'Add widgets here for the third footer column.', 'happiness-is-pets' ),
                     'before_widget' => '<div id="%1$s" class="widget %2$s">',
                     'after_widget'  => '</div>',
                     'before_title'  => '<h5 class="widget-title">',
@@ -227,9 +227,9 @@ function dreamtails_widgets_init() {
     );
     register_sidebar(
             array(
-                    'name'          => esc_html__( 'Footer Column 4', 'dreamtails' ),
+                    'name'          => esc_html__( 'Footer Column 4', 'happiness-is-pets' ),
                     'id'            => 'footer-4',
-                    'description'   => esc_html__( 'Add widgets here for the fourth footer column.', 'dreamtails' ),
+                    'description'   => esc_html__( 'Add widgets here for the fourth footer column.', 'happiness-is-pets' ),
                     'before_widget' => '<div id="%1$s" class="widget %2$s">',
                     'after_widget'  => '</div>',
                     'before_title'  => '<h5 class="widget-title">',
@@ -239,9 +239,9 @@ function dreamtails_widgets_init() {
 
     // WooCommerce Sidebar
     register_sidebar( array(
-            'name'          => esc_html__( 'Shop Sidebar', 'dreamtails' ),
+            'name'          => esc_html__( 'Shop Sidebar', 'happiness-is-pets' ),
             'id'            => 'shop-sidebar',
-            'description'   => esc_html__( 'Widgets for WooCommerce product archives.', 'dreamtails' ),
+            'description'   => esc_html__( 'Widgets for WooCommerce product archives.', 'happiness-is-pets' ),
             'before_widget' => '<div id="%1$s" class="widget %2$s">',
             'after_widget'  => '</div>',
             'before_title'  => '<h4 class="widget-title">',
@@ -250,16 +250,16 @@ function dreamtails_widgets_init() {
 
     // Offcanvas filter sidebar for WooCommerce archives
     register_sidebar( array(
-            'name'          => esc_html__( 'WooCommerce Filters', 'dreamtails' ),
+            'name'          => esc_html__( 'WooCommerce Filters', 'happiness-is-pets' ),
             'id'            => 'woocommerce-pets',
-            'description'   => esc_html__( 'Widgets displayed in the offcanvas filter on shop and category pages.', 'dreamtails' ),
+            'description'   => esc_html__( 'Widgets displayed in the offcanvas filter on shop and category pages.', 'happiness-is-pets' ),
             'before_widget' => '<div id="%1$s" class="widget %2$s">',
             'after_widget'  => '</div>',
             'before_title'  => '<h5 class="widget-title">',
             'after_title'   => '</h5>',
     ) );
 }
-add_action( 'widgets_init', 'dreamtails_widgets_init' );
+add_action( 'widgets_init', 'happiness_is_pets_widgets_init' );
 
 /**
  * Add WooCommerce Wrappers.
@@ -270,15 +270,15 @@ remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wr
 remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10);
 
 // Add theme-specific wrappers
-add_action('woocommerce_before_main_content', 'dreamtails_woocommerce_wrapper_start', 10);
-add_action('woocommerce_after_main_content', 'dreamtails_woocommerce_wrapper_end', 10);
+add_action('woocommerce_before_main_content', 'happiness_is_pets_woocommerce_wrapper_start', 10);
+add_action('woocommerce_after_main_content', 'happiness_is_pets_woocommerce_wrapper_end', 10);
 
-function dreamtails_woocommerce_wrapper_start() {
+function happiness_is_pets_woocommerce_wrapper_start() {
     // Container and row for WooCommerce pages
     echo '<main id="primary" class="site-main py-5"><div class="main-container"><div class="row">';
 }
 
-function dreamtails_woocommerce_wrapper_end() {
+function happiness_is_pets_woocommerce_wrapper_end() {
     // Close row and container
     echo '</div></div></main>';
 }
@@ -321,22 +321,22 @@ add_action( 'wp', function() {
  * Optional: Walker class for more complex menu structures.
  */
 // Basic filter to add nav-link class to menu items
-function dreamtails_add_menu_link_class( $atts, $item, $args ) {
+function happiness_is_pets_add_menu_link_class( $atts, $item, $args ) {
     if (isset($args->theme_location) && $args->theme_location === 'primary') { // Target only primary menu
         $atts['class'] = 'nav-link'; // Bootstrap 5 nav link class
     }
     return $atts;
 }
-add_filter( 'nav_menu_link_attributes', 'dreamtails_add_menu_link_class', 1, 3 );
+add_filter( 'nav_menu_link_attributes', 'happiness_is_pets_add_menu_link_class', 1, 3 );
 
 // Filter to add nav-item class to menu list items
-function dreamtails_add_menu_li_class( $classes, $item, $args ) {
+function happiness_is_pets_add_menu_li_class( $classes, $item, $args ) {
     if (isset($args->theme_location) && $args->theme_location === 'primary') {
         $classes[] = 'nav-item'; // Bootstrap 5 nav item class
     }
     return $classes;
 }
-add_filter( 'nav_menu_css_class', 'dreamtails_add_menu_li_class', 1, 3 );
+add_filter( 'nav_menu_css_class', 'happiness_is_pets_add_menu_li_class', 1, 3 );
 
 
 // Include template tags file (optional, for helper functions)
@@ -351,22 +351,22 @@ require get_template_directory() . '/inc/customizer.php';
 /**
  * Register the "reviews" custom post type.
  */
-function dreamtails_register_reviews_cpt() {
+function happiness_is_pets_register_reviews_cpt() {
     $labels = array(
-            'name'               => _x( 'Reviews', 'post type general name', 'dreamtails' ),
-            'singular_name'      => _x( 'Review', 'post type singular name', 'dreamtails' ),
-            'menu_name'          => _x( 'Reviews', 'admin menu', 'dreamtails' ),
-            'name_admin_bar'     => _x( 'Review', 'add new on admin bar', 'dreamtails' ),
-            'add_new'            => _x( 'Add New', 'review', 'dreamtails' ),
-            'add_new_item'       => __( 'Add New Review', 'dreamtails' ),
-            'new_item'           => __( 'New Review', 'dreamtails' ),
-            'edit_item'          => __( 'Edit Review', 'dreamtails' ),
-            'view_item'          => __( 'View Review', 'dreamtails' ),
-            'all_items'          => __( 'All Reviews', 'dreamtails' ),
-            'search_items'       => __( 'Search Reviews', 'dreamtails' ),
-            'parent_item_colon'  => __( 'Parent Reviews:', 'dreamtails' ),
-            'not_found'          => __( 'No reviews found.', 'dreamtails' ),
-            'not_found_in_trash' => __( 'No reviews found in Trash.', 'dreamtails' )
+            'name'               => _x( 'Reviews', 'post type general name', 'happiness-is-pets' ),
+            'singular_name'      => _x( 'Review', 'post type singular name', 'happiness-is-pets' ),
+            'menu_name'          => _x( 'Reviews', 'admin menu', 'happiness-is-pets' ),
+            'name_admin_bar'     => _x( 'Review', 'add new on admin bar', 'happiness-is-pets' ),
+            'add_new'            => _x( 'Add New', 'review', 'happiness-is-pets' ),
+            'add_new_item'       => __( 'Add New Review', 'happiness-is-pets' ),
+            'new_item'           => __( 'New Review', 'happiness-is-pets' ),
+            'edit_item'          => __( 'Edit Review', 'happiness-is-pets' ),
+            'view_item'          => __( 'View Review', 'happiness-is-pets' ),
+            'all_items'          => __( 'All Reviews', 'happiness-is-pets' ),
+            'search_items'       => __( 'Search Reviews', 'happiness-is-pets' ),
+            'parent_item_colon'  => __( 'Parent Reviews:', 'happiness-is-pets' ),
+            'not_found'          => __( 'No reviews found.', 'happiness-is-pets' ),
+            'not_found_in_trash' => __( 'No reviews found in Trash.', 'happiness-is-pets' )
     );
 
     $args = array(
@@ -387,30 +387,30 @@ function dreamtails_register_reviews_cpt() {
 
     register_post_type( 'reviews', $args );
 }
-add_action( 'init', 'dreamtails_register_reviews_cpt' );
+add_action( 'init', 'happiness_is_pets_register_reviews_cpt' );
 
 /**
  * Add meta box for star rating.
  */
-function dreamtails_reviews_add_meta_box() {
+function happiness_is_pets_reviews_add_meta_box() {
     add_meta_box(
-            'dreamtails_review_rating',
-            __( 'Star Rating', 'dreamtails' ),
-            'dreamtails_reviews_rating_meta_box_cb',
+            'happiness_is_pets_review_rating',
+            __( 'Star Rating', 'happiness-is-pets' ),
+            'happiness_is_pets_reviews_rating_meta_box_cb',
             'reviews',
             'side',
             'default'
     );
 }
-add_action( 'add_meta_boxes_reviews', 'dreamtails_reviews_add_meta_box' );
+add_action( 'add_meta_boxes_reviews', 'happiness_is_pets_reviews_add_meta_box' );
 
 /**
  * Callback to display star rating field.
  */
-function dreamtails_reviews_rating_meta_box_cb( $post ) {
-    $rating = get_post_meta( $post->ID, '_dreamtails_review_rating', true );
-    wp_nonce_field( 'dreamtails_save_review_rating', 'dreamtails_review_rating_nonce' );
-    echo '<select name="dreamtails_review_rating" id="dreamtails_review_rating" class="widefat">';
+function happiness_is_pets_reviews_rating_meta_box_cb( $post ) {
+    $rating = get_post_meta( $post->ID, '_happiness_is_pets_review_rating', true );
+    wp_nonce_field( 'happiness_is_pets_save_review_rating', 'happiness_is_pets_review_rating_nonce' );
+    echo '<select name="happiness_is_pets_review_rating" id="happiness_is_pets_review_rating" class="widefat">';
     for ( $i = 1; $i <= 5; $i++ ) {
         printf( '<option value="%1$d" %2$s>%1$d</option>', $i, selected( $rating, $i, false ) );
     }
@@ -420,8 +420,8 @@ function dreamtails_reviews_rating_meta_box_cb( $post ) {
 /**
  * Save star rating.
  */
-function dreamtails_reviews_save_meta( $post_id ) {
-    if ( ! isset( $_POST['dreamtails_review_rating_nonce'] ) || ! wp_verify_nonce( $_POST['dreamtails_review_rating_nonce'], 'dreamtails_save_review_rating' ) ) {
+function happiness_is_pets_reviews_save_meta( $post_id ) {
+    if ( ! isset( $_POST['happiness_is_pets_review_rating_nonce'] ) || ! wp_verify_nonce( $_POST['happiness_is_pets_review_rating_nonce'], 'happiness_is_pets_save_review_rating' ) ) {
         return;
     }
 
@@ -429,28 +429,28 @@ function dreamtails_reviews_save_meta( $post_id ) {
         return;
     }
 
-    if ( isset( $_POST['dreamtails_review_rating'] ) ) {
-        update_post_meta( $post_id, '_dreamtails_review_rating', intval( $_POST['dreamtails_review_rating'] ) );
+    if ( isset( $_POST['happiness_is_pets_review_rating'] ) ) {
+        update_post_meta( $post_id, '_happiness_is_pets_review_rating', intval( $_POST['happiness_is_pets_review_rating'] ) );
     }
 }
-add_action( 'save_post_reviews', 'dreamtails_reviews_save_meta' );
+add_action( 'save_post_reviews', 'happiness_is_pets_reviews_save_meta' );
 
 /**
  * Add rating column to admin list.
  */
-function dreamtails_reviews_columns( $columns ) {
-    $columns['review_rating'] = __( 'Rating', 'dreamtails' );
+function happiness_is_pets_reviews_columns( $columns ) {
+    $columns['review_rating'] = __( 'Rating', 'happiness-is-pets' );
     return $columns;
 }
-add_filter( 'manage_reviews_posts_columns', 'dreamtails_reviews_columns' );
+add_filter( 'manage_reviews_posts_columns', 'happiness_is_pets_reviews_columns' );
 
-function dreamtails_reviews_custom_column( $column, $post_id ) {
+function happiness_is_pets_reviews_custom_column( $column, $post_id ) {
     if ( 'review_rating' === $column ) {
-        $rating = intval( get_post_meta( $post_id, '_dreamtails_review_rating', true ) );
+        $rating = intval( get_post_meta( $post_id, '_happiness_is_pets_review_rating', true ) );
         echo str_repeat( '★', $rating );
     }
 }
-add_action( 'manage_reviews_posts_custom_column', 'dreamtails_reviews_custom_column', 10, 2 );
+add_action( 'manage_reviews_posts_custom_column', 'happiness_is_pets_reviews_custom_column', 10, 2 );
 
 // Disable WooCommerce page elements globally
 add_action( 'init', function() {
@@ -472,11 +472,11 @@ add_action( 'init', function() {
 
 
 // Testimonial slider
-function dreamtails_enqueue_swiper_assets() {
+function happiness_is_pets_enqueue_swiper_assets() {
     wp_enqueue_style( 'swiper-css', 'https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css' );
     wp_enqueue_script( 'swiper-js', 'https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js', array(), null, true );
 }
-add_action( 'wp_enqueue_scripts', 'dreamtails_enqueue_swiper_assets' );
+add_action( 'wp_enqueue_scripts', 'happiness_is_pets_enqueue_swiper_assets' );
 
 
 
@@ -595,13 +595,13 @@ add_filter('template_include', function($template) {
 
 /* Shortcode for the reviews slider */
 
-function dreamtails_testimonial_slider_shortcode() {
+function happiness_is_pets_testimonial_slider_shortcode() {
     ob_start();
     ?>
     <section class="front-page-section py-5" id="happy-tails">
         <div class="container">
             <h2 class="section-title text-center mb-5">
-                <?php echo esc_html( get_theme_mod( 'front_testimonial_heading', __( 'happy tails start here', 'dreamtails' ) ) ); ?>
+                <?php echo esc_html( get_theme_mod( 'front_testimonial_heading', __( 'happy tails start here', 'happiness-is-pets' ) ) ); ?>
             </h2>
 
             <?php
@@ -615,7 +615,7 @@ function dreamtails_testimonial_slider_shortcode() {
                 <div class="swiper testimonial-swiper">
                     <div class="swiper-wrapper">
                         <?php while ( $review_query->have_posts() ) : $review_query->the_post();
-                            $rating = intval( get_post_meta( get_the_ID(), '_dreamtails_review_rating', true ) );
+                            $rating = intval( get_post_meta( get_the_ID(), '_happiness_is_pets_review_rating', true ) );
                             ?>
                             <div class="swiper-slide">
                                 <div class="text-center testimonial-content px-4">
@@ -643,12 +643,12 @@ function dreamtails_testimonial_slider_shortcode() {
             <?php endif; ?>
         </div>
 
-        <!-- <img class="testimonial-decor" src="<?php //echo esc_url( get_theme_mod( 'front_testimonial_image', get_template_directory_uri() . '/assets/images/reviews-image.png' ) ); ?>" alt="<?php //esc_attr_e( 'Testimonial image', 'dreamtails' ); ?>" /> -->
+        <!-- <img class="testimonial-decor" src="<?php //echo esc_url( get_theme_mod( 'front_testimonial_image', get_template_directory_uri() . '/assets/images/reviews-image.png' ) ); ?>" alt="<?php //esc_attr_e( 'Testimonial image', 'happiness-is-pets' ); ?>" /> -->
     </section>
     <?php
     return ob_get_clean();
 }
-add_shortcode( 'dreamtails_testimonials', 'dreamtails_testimonial_slider_shortcode' );
+add_shortcode( 'happiness_is_pets_testimonials', 'happiness_is_pets_testimonial_slider_shortcode' );
 
 
 function dt_featured_pets_shortcode() {
@@ -657,7 +657,7 @@ function dt_featured_pets_shortcode() {
     <section class="front-page-section py-5 bg-light" id="featured-pets">
         <div class="container">
             <h2 class="section-title text-center mb-4">
-                <?php echo esc_html( get_theme_mod( 'front_featured_pets_heading', __( 'featured dream pets', 'dreamtails' ) ) ); ?>
+                <?php echo esc_html( get_theme_mod( 'front_featured_pets_heading', __( 'featured dream pets', 'happiness-is-pets' ) ) ); ?>
             </h2>
             <div class="row featured-pets-row align-items-center">
                 <div class="col-12 col-md-9">
@@ -671,7 +671,7 @@ function dt_featured_pets_shortcode() {
                                 <?php if ( $link ) : ?>
                                 <a href="<?php echo esc_url( $link ); ?>">
                                     <?php endif; ?>
-                                    <img src="<?php echo esc_url( $image ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Featured Pet %d', 'dreamtails' ), $i ) ); ?>" class="img-fluid">
+                                    <img src="<?php echo esc_url( $image ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Featured Pet %d', 'happiness-is-pets' ), $i ) ); ?>" class="img-fluid">
                                     <?php if ( $link ) : ?>
                                 </a>
                             <?php endif; ?>
@@ -681,7 +681,7 @@ function dt_featured_pets_shortcode() {
                 </div>
                 <div class="col-12 col-md-3 text-md-start text-center mt-3 mt-md-0 d-flex align-items-center justify-content-center">
                     <a href="/view-pets/" class="view-all-pets-link d-inline-flex align-items-center">
-                        <span class="me-2"><?php esc_html_e('View all Dream Pets', 'dreamtails'); ?></span>
+                        <span class="me-2"><?php esc_html_e('View all Dream Pets', 'happiness-is-pets'); ?></span>
                         <i class="fas fa-arrow-right"></i>
                     </a>
                 </div>

--- a/header.php
+++ b/header.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * The header for the Dream Tails theme (Two-Bar Structure with Top Offcanvas)
+ * The header for the Happiness Is Pets theme (Two-Bar Structure with Top Offcanvas)
  *
  * Displays all of the <head> section and everything up till <div id="content">
  * Implements a two-bar header:
  * 1) Top bar: Hamburger + Logo left, Contact info and Button right
  * 2) Nav bar: Menu items displayed horizontally on all devices (no hamburger)
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 ?>
 <!doctype html>
@@ -49,7 +49,7 @@
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 <div id="page" class="site">
-    <a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'dreamtails' ); ?></a>
+    <a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'happiness-is-pets' ); ?></a>
 
     <header id="masthead" class="site-header">
 
@@ -61,12 +61,12 @@
                 <div class="d-flex align-items-center">
                     <?php // Hamburger Menu Toggle ?>
                     <button
-                            class="navbar-toggler dream-tails-toggler me-2 me-md-3 d-md-none"
+                            class="navbar-toggler happiness-is-pets-toggler me-2 me-md-3 d-md-none"
                             type="button"
                             data-bs-toggle="offcanvas"
                             data-bs-target="#mobileNavOffcanvas"
                             aria-controls="mobileNavOffcanvas"
-                            aria-label="<?php esc_attr_e( 'Toggle navigation', 'dreamtails' ); ?>">
+                            aria-label="<?php esc_attr_e( 'Toggle navigation', 'happiness-is-pets' ); ?>">
                         <span class="navbar-toggler-icon"></span>
                     </button>
 
@@ -111,11 +111,11 @@
                                 <i class="fas fa-phone me-2 header-icon"></i><span class="phone-text d-none d-md-inline"><?php echo esc_html( $phone ); ?></span>
                             </a>
                         <?php endif; ?>
-                        <a href="<?php echo esc_url( function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : '#' ); ?>" class="header-icon header-account-icon me-3" aria-label="<?php esc_attr_e( 'My Account', 'dreamtails' ); ?>">
+                        <a href="<?php echo esc_url( function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : '#' ); ?>" class="header-icon header-account-icon me-3" aria-label="<?php esc_attr_e( 'My Account', 'happiness-is-pets' ); ?>">
                             <i class="fas fa-user"></i>
                         </a>
                         <?php if ( function_exists( 'wc_get_cart_url' ) && ! is_catalog_mode() ) : ?>
-                            <a href="<?php echo esc_url( wc_get_cart_url() ); ?>" class="header-icon header-cart-icon me-3" aria-label="<?php esc_attr_e( 'Shopping Cart', 'dreamtails' ); ?>">
+                            <a href="<?php echo esc_url( wc_get_cart_url() ); ?>" class="header-icon header-cart-icon me-3" aria-label="<?php esc_attr_e( 'Shopping Cart', 'happiness-is-pets' ); ?>">
                                 <i class="fas fa-shopping-cart"></i>
                             </a>
                         <?php endif; ?>
@@ -126,7 +126,7 @@
         </div>
 
         <?php // --- Offcanvas Menu (Triggered by hamburger in top bar) --- ?>
-        <div class="offcanvas offcanvas-start dream-tails-offcanvas" tabindex="-1" id="mobileNavOffcanvas" aria-labelledby="mobileNavOffcanvasLabel">
+        <div class="offcanvas offcanvas-start happiness-is-pets-offcanvas" tabindex="-1" id="mobileNavOffcanvas" aria-labelledby="mobileNavOffcanvasLabel">
             <div class="offcanvas-header">
                 <div class="offcanvas-logo">
                     <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
@@ -139,7 +139,7 @@
                         <?php } ?>
                     </a>
                 </div>
-                <button type="button" class="btn-close dream-tails-close" data-bs-dismiss="offcanvas" aria-label="<?php esc_attr_e( 'Close', 'dreamtails' ); ?>"></button>
+                <button type="button" class="btn-close happiness-is-pets-close" data-bs-dismiss="offcanvas" aria-label="<?php esc_attr_e( 'Close', 'happiness-is-pets' ); ?>"></button>
             </div>
             <div class="offcanvas-body">
                 <?php // Full Navigation Menu in Offcanvas ?>
@@ -160,16 +160,16 @@
 
                 <?php // Mobile Quick Links ?>
                 <div class="mobile-quick-links">
-                    <h6 class="quick-links-title"><?php esc_html_e( 'Quick Links', 'dreamtails' ); ?></h6>
+                    <h6 class="quick-links-title"><?php esc_html_e( 'Quick Links', 'happiness-is-pets' ); ?></h6>
                     <div class="quick-links-grid">
                         <a href="<?php echo esc_url( function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : '#' ); ?>" class="quick-link-item">
                             <i class="fas fa-user"></i>
-                            <span><?php esc_html_e( 'My Account', 'dreamtails' ); ?></span>
+                            <span><?php esc_html_e( 'My Account', 'happiness-is-pets' ); ?></span>
                         </a>
                         <?php if ( function_exists( 'wc_get_cart_url' ) && ! is_catalog_mode() ) : ?>
                             <a href="<?php echo esc_url( wc_get_cart_url() ); ?>" class="quick-link-item">
                                 <i class="fas fa-shopping-cart"></i>
-                                <span><?php esc_html_e( 'Cart', 'dreamtails' ); ?></span>
+                                <span><?php esc_html_e( 'Cart', 'happiness-is-pets' ); ?></span>
                             </a>
                         <?php endif; ?>
                     </div>
@@ -195,10 +195,10 @@
 
                 <?php // Mobile Social Links ?>
                 <div class="mobile-social-links">
-                    <a href="<?php echo esc_url( get_theme_mod( 'footer_facebook_url', '#' ) ); ?>" class="social-link" aria-label="<?php esc_attr_e( 'Facebook', 'dreamtails' ); ?>">
+                    <a href="<?php echo esc_url( get_theme_mod( 'footer_facebook_url', '#' ) ); ?>" class="social-link" aria-label="<?php esc_attr_e( 'Facebook', 'happiness-is-pets' ); ?>">
                         <i class="fab fa-facebook-f"></i>
                     </a>
-                    <a href="<?php echo esc_url( get_theme_mod( 'footer_instagram_url', '#' ) ); ?>" class="social-link" aria-label="<?php esc_attr_e( 'Instagram', 'dreamtails' ); ?>">
+                    <a href="<?php echo esc_url( get_theme_mod( 'footer_instagram_url', '#' ) ); ?>" class="social-link" aria-label="<?php esc_attr_e( 'Instagram', 'happiness-is-pets' ); ?>">
                         <i class="fab fa-instagram"></i>
                     </a>
                 </div>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Theme Customizer additions for Dream Tails.
+ * Theme Customizer additions for Happiness Is Pets.
  */
 
-function dreamtails_customize_register( $wp_customize ) {
+function happiness_is_pets_customize_register( $wp_customize ) {
     // Panel for front page settings
-    $wp_customize->add_panel( 'dreamtails_front_page', array(
-            'title'    => __( 'Front Page', 'dreamtails' ),
+    $wp_customize->add_panel( 'happiness_is_pets_front_page', array(
+            'title'    => __( 'Front Page', 'happiness-is-pets' ),
             'priority' => 160,
     ) );
 
     /* Hero Section */
-    $wp_customize->add_section( 'dreamtails_hero', array(
-            'title' => __( 'Hero Section', 'dreamtails' ),
-            'panel' => 'dreamtails_front_page',
+    $wp_customize->add_section( 'happiness_is_pets_hero', array(
+            'title' => __( 'Hero Section', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_front_page',
     ) );
 
     $wp_customize->add_setting( 'front_hero_image', array(
@@ -22,27 +22,27 @@ function dreamtails_customize_register( $wp_customize ) {
     ) );
 
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_hero_image', array(
-            'label'   => __( 'Hero Image', 'dreamtails' ),
-            'section' => 'dreamtails_hero',
+            'label'   => __( 'Hero Image', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_hero',
     ) ) );
 
     $wp_customize->add_setting( 'front_hero_heading', array(
-            'default'           => __( 'where pets find their people', 'dreamtails' ),
+            'default'           => __( 'where pets find their people', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_hero_heading', array(
-            'label'   => __( 'Hero Heading', 'dreamtails' ),
-            'section' => 'dreamtails_hero',
+            'label'   => __( 'Hero Heading', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_hero',
             'type'    => 'text',
     ) );
 
     $wp_customize->add_setting( 'front_hero_button_text', array(
-            'default'           => __( 'Book an Appointment', 'dreamtails' ),
+            'default'           => __( 'Book an Appointment', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_hero_button_text', array(
-            'label'   => __( 'Hero Button Text', 'dreamtails' ),
-            'section' => 'dreamtails_hero',
+            'label'   => __( 'Hero Button Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_hero',
             'type'    => 'text',
     ) );
 
@@ -52,8 +52,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_hero_bg_image', array(
-            'label'   => __( 'Hero Background Image', 'dreamtails' ),
-            'section' => 'dreamtails_hero',
+            'label'   => __( 'Hero Background Image', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_hero',
     ) ) );
 
     $wp_customize->add_setting( 'front_hero_bg_color', array(
@@ -61,13 +61,13 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'sanitize_hex_color',
     ) );
     $wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'front_hero_bg_color', array(
-            'label'   => __( 'Hero Background Color', 'dreamtails' ),
-            'section' => 'dreamtails_hero',
+            'label'   => __( 'Hero Background Color', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_hero',
     ) ) );
 
     /* Header Settings */
-    $wp_customize->add_section( 'dreamtails_header_settings', array(
-            'title'    => __( 'Header Settings', 'dreamtails' ),
+    $wp_customize->add_section( 'happiness_is_pets_header_settings', array(
+            'title'    => __( 'Header Settings', 'happiness-is-pets' ),
             'priority' => 30,
     ) );
 
@@ -76,8 +76,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'header_phone_number', array(
-            'label'   => __( 'Phone Number', 'dreamtails' ),
-            'section' => 'dreamtails_header_settings',
+            'label'   => __( 'Phone Number', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_header_settings',
             'type'    => 'text',
     ) );
 
@@ -86,18 +86,18 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( 'header_book_button_url', array(
-            'label'   => __( 'Reservation Button URL', 'dreamtails' ),
-            'section' => 'dreamtails_header_settings',
+            'label'   => __( 'Reservation Button URL', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_header_settings',
             'type'    => 'url',
     ) );
 
     $wp_customize->add_setting( 'header_book_button_text', array(
-            'default'           => __( 'Make a Reservation', 'dreamtails' ),
+            'default'           => __( 'Make a Reservation', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'header_book_button_text', array(
-            'label'   => __( 'Reservation Button Text', 'dreamtails' ),
-            'section' => 'dreamtails_header_settings',
+            'label'   => __( 'Reservation Button Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_header_settings',
             'type'    => 'text',
     ) );
 
@@ -106,16 +106,16 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'header_book_button_icon', array(
-            'label'       => __( 'Reservation Button Icon', 'dreamtails' ),
-            'section'     => 'dreamtails_header_settings',
+            'label'       => __( 'Reservation Button Icon', 'happiness-is-pets' ),
+            'section'     => 'happiness_is_pets_header_settings',
             'type'        => 'text',
-            'description' => __( 'Font Awesome class, e.g. fa-calendar-check', 'dreamtails' ),
+            'description' => __( 'Font Awesome class, e.g. fa-calendar-check', 'happiness-is-pets' ),
     ) );
 
     /* Shop Settings */
-    $wp_customize->add_section( 'dreamtails_shop_settings', array(
-            'title' => __( 'Shop Settings', 'dreamtails' ),
-            'panel' => 'dreamtails_front_page',
+    $wp_customize->add_section( 'happiness_is_pets_shop_settings', array(
+            'title' => __( 'Shop Settings', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_front_page',
     ) );
 
     // FIXED: Changed to boolean handling for checkbox
@@ -127,15 +127,15 @@ function dreamtails_customize_register( $wp_customize ) {
     ) );
 
     $wp_customize->add_control( 'enable_catalog_mode', array(
-            'label'   => __( 'Enable Catalog Mode', 'dreamtails' ),
-            'section' => 'dreamtails_shop_settings',
+            'label'   => __( 'Enable Catalog Mode', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_shop_settings',
             'type'    => 'checkbox',
     ) );
 
     /* Icon Section */
-    $wp_customize->add_section( 'dreamtails_icons', array(
-            'title' => __( 'Icon Section', 'dreamtails' ),
-            'panel' => 'dreamtails_front_page',
+    $wp_customize->add_section( 'happiness_is_pets_icons', array(
+            'title' => __( 'Icon Section', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_front_page',
     ) );
 
     $wp_customize->add_setting( 'front_icon1_img', array(
@@ -143,8 +143,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_icon1_img', array(
-            'label'   => __( 'First Icon Image', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'First Icon Image', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
     ) ) );
 
     $wp_customize->add_setting( 'front_icon1_link', array(
@@ -152,18 +152,18 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( 'front_icon1_link', array(
-            'label'   => __( 'First Icon Link', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'First Icon Link', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
             'type'    => 'url',
     ) );
 
     $wp_customize->add_setting( 'front_icon1_text', array(
-            'default'           => __( 'puppies dreaming of you', 'dreamtails' ),
+            'default'           => __( 'puppies dreaming of you', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_icon1_text', array(
-            'label'   => __( 'First Icon Text', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'First Icon Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
             'type'    => 'text',
     ) );
 
@@ -172,8 +172,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_icon2_img', array(
-            'label'   => __( 'Second Icon Image', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'Second Icon Image', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
     ) ) );
 
     $wp_customize->add_setting( 'front_icon2_link', array(
@@ -181,18 +181,18 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( 'front_icon2_link', array(
-            'label'   => __( 'Second Icon Link', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'Second Icon Link', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
             'type'    => 'url',
     ) );
 
     $wp_customize->add_setting( 'front_icon2_text', array(
-            'default'           => __( 'kittens dreaming of you', 'dreamtails' ),
+            'default'           => __( 'kittens dreaming of you', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_icon2_text', array(
-            'label'   => __( 'Second Icon Text', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'Second Icon Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
             'type'    => 'text',
     ) );
 
@@ -201,8 +201,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_icon3_img', array(
-            'label'   => __( 'Third Icon Image', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'Third Icon Image', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
     ) ) );
 
     $wp_customize->add_setting( 'front_icon3_link', array(
@@ -210,34 +210,34 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( 'front_icon3_link', array(
-            'label'   => __( 'Third Icon Link', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'Third Icon Link', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
             'type'    => 'url',
     ) );
 
     $wp_customize->add_setting( 'front_icon3_text', array(
-            'default'           => __( 'concierge service', 'dreamtails' ),
+            'default'           => __( 'concierge service', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_icon3_text', array(
-            'label'   => __( 'Third Icon Text', 'dreamtails' ),
-            'section' => 'dreamtails_icons',
+            'label'   => __( 'Third Icon Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_icons',
             'type'    => 'text',
     ) );
 
     /* Featured Pets */
-    $wp_customize->add_section( 'dreamtails_featured_pets', array(
-            'title' => __( 'Featured Pets', 'dreamtails' ),
-            'panel' => 'dreamtails_front_page',
+    $wp_customize->add_section( 'happiness_is_pets_featured_pets', array(
+            'title' => __( 'Featured Pets', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_front_page',
     ) );
 
     $wp_customize->add_setting( 'front_featured_pets_heading', array(
-            'default'           => __( 'featured dream pets', 'dreamtails' ),
+            'default'           => __( 'featured dream pets', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_featured_pets_heading', array(
-            'label'   => __( 'Section Heading', 'dreamtails' ),
-            'section' => 'dreamtails_featured_pets',
+            'label'   => __( 'Section Heading', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_featured_pets',
             'type'    => 'text',
     ) );
 
@@ -248,8 +248,8 @@ function dreamtails_customize_register( $wp_customize ) {
                 'sanitize_callback' => 'esc_url_raw',
         ) );
         $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, "front_featured_pet_image{$i}", array(
-                'label'   => sprintf( __( 'Featured Pet Image %d', 'dreamtails' ), $i ),
-                'section' => 'dreamtails_featured_pets',
+                'label'   => sprintf( __( 'Featured Pet Image %d', 'happiness-is-pets' ), $i ),
+                'section' => 'happiness_is_pets_featured_pets',
         ) ) );
 
         $wp_customize->add_setting( "front_featured_pet_link{$i}", array(
@@ -257,25 +257,25 @@ function dreamtails_customize_register( $wp_customize ) {
                 'sanitize_callback' => 'esc_url_raw',
         ) );
         $wp_customize->add_control( "front_featured_pet_link{$i}", array(
-                'label'   => sprintf( __( 'Featured Pet Link %d', 'dreamtails' ), $i ),
-                'section' => 'dreamtails_featured_pets',
+                'label'   => sprintf( __( 'Featured Pet Link %d', 'happiness-is-pets' ), $i ),
+                'section' => 'happiness_is_pets_featured_pets',
                 'type'    => 'url',
         ) );
     }
 
     /* Testimonials */
-    $wp_customize->add_section( 'dreamtails_testimonials', array(
-            'title' => __( 'Testimonials', 'dreamtails' ),
-            'panel' => 'dreamtails_front_page',
+    $wp_customize->add_section( 'happiness_is_pets_testimonials', array(
+            'title' => __( 'Testimonials', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_front_page',
     ) );
 
     $wp_customize->add_setting( 'front_testimonial_heading', array(
-            'default'           => __( 'happy tails start here', 'dreamtails' ),
+            'default'           => __( 'happy tails start here', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_testimonial_heading', array(
-            'label'   => __( 'Section Heading', 'dreamtails' ),
-            'section' => 'dreamtails_testimonials',
+            'label'   => __( 'Section Heading', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_testimonials',
             'type'    => 'text',
     ) );
 
@@ -284,8 +284,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_testimonial_image', array(
-            'label'   => __( 'Testimonial Image', 'dreamtails' ),
-            'section' => 'dreamtails_testimonials',
+            'label'   => __( 'Testimonial Image', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_testimonials',
     ) ) );
 
     // Background options for Testimonials Section
@@ -294,8 +294,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_testimonial_bg_image', array(
-            'label'   => __( 'Testimonials Background Image', 'dreamtails' ),
-            'section' => 'dreamtails_testimonials',
+            'label'   => __( 'Testimonials Background Image', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_testimonials',
     ) ) );
 
     $wp_customize->add_setting( 'front_testimonial_bg_color', array(
@@ -303,53 +303,53 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'sanitize_hex_color',
     ) );
     $wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'front_testimonial_bg_color', array(
-            'label'   => __( 'Testimonials Background Color', 'dreamtails' ),
-            'section' => 'dreamtails_testimonials',
+            'label'   => __( 'Testimonials Background Color', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_testimonials',
     ) ) );
 
     /* Concierge Section */
-    $wp_customize->add_section( 'dreamtails_concierge', array(
-            'title' => __( 'Concierge Section', 'dreamtails' ),
-            'panel' => 'dreamtails_front_page',
+    $wp_customize->add_section( 'happiness_is_pets_concierge', array(
+            'title' => __( 'Concierge Section', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_front_page',
     ) );
 
     $wp_customize->add_setting( 'front_concierge_heading', array(
-            'default'           => __( 'concierge level care', 'dreamtails' ),
+            'default'           => __( 'concierge level care', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_concierge_heading', array(
-            'label'   => __( 'Section Heading', 'dreamtails' ),
-            'section' => 'dreamtails_concierge',
+            'label'   => __( 'Section Heading', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_concierge',
             'type'    => 'text',
     ) );
 
     $wp_customize->add_setting( 'front_concierge_lead', array(
-            'default'           => __( 'Our service and environment are designed to match the high quality of puppies and kittens in our store and meet your expectations.', 'dreamtails' ),
+            'default'           => __( 'Our service and environment are designed to match the high quality of puppies and kittens in our store and meet your expectations.', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_textarea_field',
     ) );
     $wp_customize->add_control( 'front_concierge_lead', array(
-            'label'   => __( 'Lead Text', 'dreamtails' ),
-            'section' => 'dreamtails_concierge',
+            'label'   => __( 'Lead Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_concierge',
             'type'    => 'textarea',
     ) );
 
     $wp_customize->add_setting( 'front_concierge_desc', array(
-            'default'           => __( 'We think the puppies and kittens are worth it and so are you!', 'dreamtails' ),
+            'default'           => __( 'We think the puppies and kittens are worth it and so are you!', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_textarea_field',
     ) );
     $wp_customize->add_control( 'front_concierge_desc', array(
-            'label'   => __( 'Secondary Text', 'dreamtails' ),
-            'section' => 'dreamtails_concierge',
+            'label'   => __( 'Secondary Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_concierge',
             'type'    => 'textarea',
     ) );
 
     $wp_customize->add_setting( 'front_concierge_button_text', array(
-            'default'           => __( 'Learn more about Dream Tails Boutique', 'dreamtails' ),
+            'default'           => __( 'Learn more about Happiness Is Pets Boutique', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'front_concierge_button_text', array(
-            'label'   => __( 'Button Text', 'dreamtails' ),
-            'section' => 'dreamtails_concierge',
+            'label'   => __( 'Button Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_concierge',
             'type'    => 'text',
     ) );
 
@@ -358,30 +358,30 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( 'front_concierge_button_url', array(
-            'label'   => __( 'Button URL', 'dreamtails' ),
-            'section' => 'dreamtails_concierge',
+            'label'   => __( 'Button URL', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_concierge',
             'type'    => 'url',
     ) );
 
     /* Footer Panel */
-    $wp_customize->add_panel( 'dreamtails_footer', array(
-            'title'    => __( 'Footer', 'dreamtails' ),
+    $wp_customize->add_panel( 'happiness_is_pets_footer', array(
+            'title'    => __( 'Footer', 'happiness-is-pets' ),
             'priority' => 200,
     ) );
 
     /* Footer Column 1 */
-    $wp_customize->add_section( 'dreamtails_footer_col1', array(
-            'title' => __( 'Column 1', 'dreamtails' ),
-            'panel' => 'dreamtails_footer',
+    $wp_customize->add_section( 'happiness_is_pets_footer_col1', array(
+            'title' => __( 'Column 1', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_footer',
     ) );
 
     $wp_customize->add_setting( 'footer_col1_heading', array(
-            'default'           => __( 'Navigation', 'dreamtails' ),
+            'default'           => __( 'Navigation', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'footer_col1_heading', array(
-            'label'   => __( 'Heading', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col1',
+            'label'   => __( 'Heading', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col1',
             'type'    => 'text',
     ) );
 
@@ -390,24 +390,24 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'wp_kses_post',
     ) );
     $wp_customize->add_control( 'footer_col1_text', array(
-            'label'   => __( 'Additional Text', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col1',
+            'label'   => __( 'Additional Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col1',
             'type'    => 'textarea',
     ) );
 
     /* Footer Column 2 */
-    $wp_customize->add_section( 'dreamtails_footer_col2', array(
-            'title' => __( 'Column 2', 'dreamtails' ),
-            'panel' => 'dreamtails_footer',
+    $wp_customize->add_section( 'happiness_is_pets_footer_col2', array(
+            'title' => __( 'Column 2', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_footer',
     ) );
 
     $wp_customize->add_setting( 'footer_col2_heading', array(
-            'default'           => __( 'Dream Tails Sarasota', 'dreamtails' ),
+            'default'           => __( 'Happiness Is Pets Sarasota', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'footer_col2_heading', array(
-            'label'   => __( 'Heading', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col2',
+            'label'   => __( 'Heading', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col2',
             'type'    => 'text',
     ) );
 
@@ -416,8 +416,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'sanitize_textarea_field',
     ) );
     $wp_customize->add_control( 'footer_col2_address', array(
-            'label'   => __( 'Address', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col2',
+            'label'   => __( 'Address', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col2',
             'type'    => 'textarea',
     ) );
 
@@ -426,24 +426,24 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'footer_col2_phone', array(
-            'label'   => __( 'Phone Number', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col2',
+            'label'   => __( 'Phone Number', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col2',
             'type'    => 'text',
     ) );
 
     /* Footer Column 3 */
-    $wp_customize->add_section( 'dreamtails_footer_col3', array(
-            'title' => __( 'Column 3', 'dreamtails' ),
-            'panel' => 'dreamtails_footer',
+    $wp_customize->add_section( 'happiness_is_pets_footer_col3', array(
+            'title' => __( 'Column 3', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_footer',
     ) );
 
     $wp_customize->add_setting( 'footer_col3_heading', array(
-            'default'           => __( 'Store Hours', 'dreamtails' ),
+            'default'           => __( 'Store Hours', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'footer_col3_heading', array(
-            'label'   => __( 'Heading', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col3',
+            'label'   => __( 'Heading', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col3',
             'type'    => 'text',
     ) );
 
@@ -452,34 +452,34 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'sanitize_textarea_field',
     ) );
     $wp_customize->add_control( 'footer_col3_hours', array(
-            'label'   => __( 'Hours', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col3',
+            'label'   => __( 'Hours', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col3',
             'type'    => 'textarea',
     ) );
 
     /* Footer Column 4 */
-    $wp_customize->add_section( 'dreamtails_footer_col4', array(
-            'title' => __( 'Column 4', 'dreamtails' ),
-            'panel' => 'dreamtails_footer',
+    $wp_customize->add_section( 'happiness_is_pets_footer_col4', array(
+            'title' => __( 'Column 4', 'happiness-is-pets' ),
+            'panel' => 'happiness_is_pets_footer',
     ) );
 
     $wp_customize->add_setting( 'footer_col4_heading', array(
-            'default'           => __( 'About Us', 'dreamtails' ),
+            'default'           => __( 'About Us', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'footer_col4_heading', array(
-            'label'   => __( 'Heading', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col4',
+            'label'   => __( 'Heading', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col4',
             'type'    => 'text',
     ) );
 
     $wp_customize->add_setting( 'footer_col4_text', array(
-            'default'           => __( 'Part of the Petland family of stores.', 'dreamtails' ),
+            'default'           => __( 'Part of the Petland family of stores.', 'happiness-is-pets' ),
             'sanitize_callback' => 'sanitize_textarea_field',
     ) );
     $wp_customize->add_control( 'footer_col4_text', array(
-            'label'   => __( 'Text', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col4',
+            'label'   => __( 'Text', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col4',
             'type'    => 'textarea',
     ) );
 
@@ -488,8 +488,8 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( 'footer_facebook_url', array(
-            'label'   => __( 'Facebook URL', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col4',
+            'label'   => __( 'Facebook URL', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col4',
             'type'    => 'url',
     ) );
 
@@ -498,17 +498,17 @@ function dreamtails_customize_register( $wp_customize ) {
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( 'footer_instagram_url', array(
-            'label'   => __( 'Instagram URL', 'dreamtails' ),
-            'section' => 'dreamtails_footer_col4',
+            'label'   => __( 'Instagram URL', 'happiness-is-pets' ),
+            'section' => 'happiness_is_pets_footer_col4',
             'type'    => 'url',
     ) );
 }
-add_action( 'customize_register', 'dreamtails_customize_register' );
+add_action( 'customize_register', 'happiness_is_pets_customize_register' );
 
 /**
  * Output dynamic CSS based on customizer settings.
  */
-function dreamtails_customizer_css() {
+function happiness_is_pets_customizer_css() {
     $hero            = get_theme_mod( 'front_hero_image', get_template_directory_uri() . '/assets/images/homepage_hero.png' );
     $hero_bg_image   = get_theme_mod( 'front_hero_bg_image', '' );
     $hero_bg_color   = get_theme_mod( 'front_hero_bg_color', '#ffcfcd' );
@@ -542,4 +542,4 @@ function dreamtails_customizer_css() {
     </style>
     <?php
 }
-add_action( 'wp_head', 'dreamtails_customizer_css' );
+add_action( 'wp_head', 'happiness_is_pets_customizer_css' );

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 get_header();
@@ -50,9 +50,9 @@ get_header();
 
                     // Add pagination if needed
                     the_posts_pagination( array(
-                        'prev_text' => '<i class="fas fa-arrow-left"></i><span class="screen-reader-text">' . __( 'Previous page', 'dreamtails' ) . '</span>',
-                        'next_text' => '<span class="screen-reader-text">' . __( 'Next page', 'dreamtails' ) . '</span><i class="fas fa-arrow-right"></i>',
-                        'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'dreamtails' ) . ' </span>',
+                        'prev_text' => '<i class="fas fa-arrow-left"></i><span class="screen-reader-text">' . __( 'Previous page', 'happiness-is-pets' ) . '</span>',
+                        'next_text' => '<span class="screen-reader-text">' . __( 'Next page', 'happiness-is-pets' ) . '</span><i class="fas fa-arrow-right"></i>',
+                        'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'happiness-is-pets' ) . ' </span>',
                         // Add Bootstrap pagination classes if desired
                         'type'      => 'list', // Use list format for easier Bootstrap styling
                         'echo'      => false   // Return the links to maybe wrap them later
@@ -60,7 +60,7 @@ get_header();
                 // Example: Wrap pagination with Bootstrap classes
                 // $pagination_links = the_posts_pagination( ... 'echo' => false ... );
                 // if ( $pagination_links ) {
-                //    echo '<nav class="navigation posts-navigation" aria-label="' . esc_attr__( 'Posts', 'dreamtails' ) . '"><ul class="pagination justify-content-center">' . $pagination_links . '</ul></nav>';
+                //    echo '<nav class="navigation posts-navigation" aria-label="' . esc_attr__( 'Posts', 'happiness-is-pets' ) . '"><ul class="pagination justify-content-center">' . $pagination_links . '</ul></nav>';
                 // }
 
 

--- a/page-all-pets.php
+++ b/page-all-pets.php
@@ -3,7 +3,7 @@
  * Template Name: All Pets
  * Description: Displays all products excluding the Accessories category.
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 get_header();
@@ -12,7 +12,7 @@ get_template_part( 'template-parts/page', 'header' );
 
 <div class="main-container">
     <div class="breadcrumbs small mb-4">
-        <?php if ( function_exists( 'dreamtails_breadcrumb' ) ) { dreamtails_breadcrumb(); } ?>
+        <?php if ( function_exists( 'happiness_is_pets_breadcrumb' ) ) { happiness_is_pets_breadcrumb(); } ?>
     </div>
 </div>
 

--- a/page.php
+++ b/page.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * The template for displaying all static pages
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 get_header();

--- a/sidebar-shop.php
+++ b/sidebar-shop.php
@@ -2,7 +2,7 @@
 /**
  * Sidebar for WooCommerce shop and product category pages.
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 if ( is_active_sidebar( 'shop-sidebar' ) ) : ?>

--- a/sidebar-woocommerce-pets.php
+++ b/sidebar-woocommerce-pets.php
@@ -2,7 +2,7 @@
 /**
  * Sidebar used inside the pets filter offcanvas.
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 if ( is_active_sidebar( 'woocommerce-pets' ) ) : ?>

--- a/single.php
+++ b/single.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * The template for displaying all single posts
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 get_header();
@@ -20,8 +20,8 @@ get_template_part( 'template-parts/page', 'header' );
 
                     // Previous/next post navigation.
                     the_post_navigation( array(
-                        'prev_text' => '<span class="nav-subtitle">' . esc_html__( 'Previous:', 'dreamtails' ) . '</span> <span class="nav-title">%title</span>',
-                        'next_text' => '<span class="nav-subtitle">' . esc_html__( 'Next:', 'dreamtails' ) . '</span> <span class="nav-title">%title</span>',
+                        'prev_text' => '<span class="nav-subtitle">' . esc_html__( 'Previous:', 'happiness-is-pets' ) . '</span> <span class="nav-title">%title</span>',
+                        'next_text' => '<span class="nav-subtitle">' . esc_html__( 'Next:', 'happiness-is-pets' ) . '</span> <span class="nav-title">%title</span>',
                     ) );
 
 

--- a/style.css
+++ b/style.css
@@ -1,14 +1,14 @@
 /*
-Theme Name: Dream Tails
+Theme Name: Happiness Is Pets
 Theme URI: https://cosmickmedia.com/
 Author: Cosmick Media
 Author URI: https://cosmickmedia.com/
-Description: Custom theme for Dream Tails Boutique integrating Bootstrap 5, Font Awesome 6, and WooCommerce support.
+Description: Custom theme for Happiness Is Pets Boutique integrating Bootstrap 5, Font Awesome 6, and WooCommerce support.
 Version: 1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: custom-background, custom-logo, custom-menu, featured-images, theme-options, translation-ready, block-styles, responsive-layout, two-columns, left-sidebar, right-sidebar, woocommerce
-Text Domain: dreamtails
+Text Domain: happiness-is-pets
 */
 
 /* --- Variables --- */
@@ -203,7 +203,7 @@ a:hover {
 
 
 /* --- Hamburger Toggle in Top Bar --- */
-.dream-tails-toggler {
+.happiness-is-pets-toggler {
     border: none;
     background-color: transparent;
     border-radius: 8px;
@@ -213,14 +213,14 @@ a:hover {
     transition: background-color 0.3s ease;
 }
 
-.dream-tails-toggler:hover,
-.dream-tails-toggler:focus {
+.happiness-is-pets-toggler:hover,
+.happiness-is-pets-toggler:focus {
     background-color: rgba(61, 81, 85, 0.05);
     outline: none;
     box-shadow: none;
 }
 
-.dream-tails-toggler .navbar-toggler-icon {
+.happiness-is-pets-toggler .navbar-toggler-icon {
     width: 1.5em;
     height: 1.5em;
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(61, 81, 85, 0.8)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2.5' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
@@ -294,29 +294,29 @@ a:hover {
 }
 
 /* --- Offcanvas Mobile Menu Styles --- */
-.dream-tails-offcanvas {
+.happiness-is-pets-offcanvas {
     max-width: 85%;
     background-color: #FFFFFF;
 }
 
 @media (min-width: 576px) {
-    .dream-tails-offcanvas {
+    .happiness-is-pets-offcanvas {
         max-width: 400px;
     }
 }
 
-.dream-tails-offcanvas .offcanvas-header {
+.happiness-is-pets-offcanvas .offcanvas-header {
     background-color: var(--color-primary-light-blue-grey);
     padding: 1.5rem;
     border-bottom: 3px solid var(--color-secondary-light-pink);
 }
 
-.dream-tails-offcanvas .offcanvas-logo img {
+.happiness-is-pets-offcanvas .offcanvas-logo img {
     max-height: 60px;
     width: auto;
 }
 
-.dream-tails-offcanvas .dream-tails-close {
+.happiness-is-pets-offcanvas .happiness-is-pets-close {
     background-color: white;
     border-radius: 50%;
     opacity: 1;
@@ -325,12 +325,12 @@ a:hover {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.dream-tails-offcanvas .dream-tails-close:hover {
+.happiness-is-pets-offcanvas .happiness-is-pets-close:hover {
     transform: rotate(90deg);
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.15);
 }
 
-.dream-tails-offcanvas .offcanvas-body {
+.happiness-is-pets-offcanvas .offcanvas-body {
     padding: 0;
     display: flex;
     flex-direction: column;
@@ -547,7 +547,7 @@ a:hover {
 }
 
 /* Transition Animation */
-.dream-tails-offcanvas.show {
+.happiness-is-pets-offcanvas.show {
     animation: slideIn 0.3s ease-out;
 }
 
@@ -945,7 +945,7 @@ display:none !important;
     padding-top: 20px;
     padding-bottom: 20px;
     margin-bottom: 60px;
-    background-image: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg)
+    background-image: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg)
 }
 
 .footer-menu {
@@ -976,7 +976,7 @@ display:none !important;
  
 .about-us-para {
     padding: 40px 40px;
-    background: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
+    background: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
     border-radius: 20px;
     color: #2e334e;
 }
@@ -1015,7 +1015,7 @@ border-radius: 10px;
  
 .wp-block-group.akc-page-cust:nth-child(2n) {
     background: #ffd3d2;
-    background-image: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
+    background-image: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
 }
  
 .wp-block-group.akc-page-cust {
@@ -1320,7 +1320,7 @@ form#gform_3 {
 }
 .form-heading {
     padding: 20px;
-    background-image: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
+    background-image: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
     border-radius: 10px 10px 0 0;
     border: 1px solid #ffb7b5;
     border-bottom: none;
@@ -1387,7 +1387,7 @@ color:#3d5155;
 
 
 .wp-block-group.apply-on-cust {
-    background: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
+    background: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
     height: 400px;
     padding: 150px 0 0 0;
     width: 100%;
@@ -1421,7 +1421,7 @@ figure.wp-block-image.size-full.financing-cat {
     line-height: 30px;
 }
 /* .wp-block-group.apply-on-cust {
-    background: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
+    background: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
     height: 300px;
     padding: 80px 0 0 0;
     width: 100%;
@@ -1443,7 +1443,7 @@ figure.wp-block-image.size-full.financing-cat {
     color: #000;
 }
 .need-help-group{
-    background: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
+    background: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
     margin-top: 80px;
     padding: 80px 0 !important;
     margin-bottom: 0 !important;
@@ -1497,7 +1497,7 @@ figure.wp-block-image.size-full.financing-cat {
     font-size: 18px;
 }
 .book-appointment-cust {
-    background: url('https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg');
+    background: url('https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg');
     padding: 70px 0 !important;
 }
 .book-appointment-cust p {
@@ -1550,7 +1550,7 @@ border-radius: 72px;
     height: 450px;margin:0px;
 }
 .wp-block-group.our-goals.category-image-content-main-group {
-    background: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
+    background: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
     padding: 120px 0 0 0 !important;
     height: 300px;
     width: 100%;
@@ -1798,7 +1798,7 @@ figure.wp-block-image.size-full.financing-cat {
     grid-template-columns: auto;
 }
 .wp-block-group.apply-on-cust {
-    background: url(https://dreamtails.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
+    background: url(https://happiness-is-pets.kinsta.cloud/wp-content/uploads/2025/06/clouds.jpg);
     height: auto;
     padding: 60px 0 60px 0;
    
@@ -2486,20 +2486,20 @@ color: #2d3e40 !important;
             text-align: center;
         }
 
-        /* --- Dreamtails Difference Section --- */
-        .dreamtails-difference-section {
+        /* --- Happiness Is Pets Difference Section --- */
+        .happiness-is-pets-difference-section {
             background-color: #f8f9fa;
             padding: 4rem 0;
             margin-top: 0;
         }
 
-        .dreamtails-difference-content {
+        .happiness-is-pets-difference-content {
             max-width: 1200px;
             margin: 0 auto;
             padding: 0 1rem;
         }
 
-        .dreamtails-difference-content h2 {
+        .happiness-is-pets-difference-content h2 {
             font-family: "Mollie Glaston", sans-serif;
             font-size: 2rem;
             color: #41545f;
@@ -2508,7 +2508,7 @@ color: #2d3e40 !important;
             align-items: center;
         }
 
-        .dreamtails-difference-content h2 i {
+        .happiness-is-pets-difference-content h2 i {
             color: #41545f;
             margin-right: 1rem;
             font-size: 2.5rem;
@@ -2542,10 +2542,10 @@ color: #2d3e40 !important;
                 padding: 4rem 0;
                 margin-top: 4rem;
             }
-            .dreamtails-difference-section {
+            .happiness-is-pets-difference-section {
                 padding: 3rem 0;
             }
-            .dreamtails-difference-content h2 {
+            .happiness-is-pets-difference-content h2 {
                 font-size: 1.75rem;
             }
         }
@@ -2561,13 +2561,13 @@ color: #2d3e40 !important;
                 padding: 3rem 0;
                 margin-top: 3rem;
             }
-            .dreamtails-difference-section {
+            .happiness-is-pets-difference-section {
                 padding: 2.5rem 0;
             }
-            .dreamtails-difference-content h2 {
+            .happiness-is-pets-difference-content h2 {
                 font-size: 1.5rem;
             }
-            .dreamtails-difference-content h2 i {
+            .happiness-is-pets-difference-content h2 i {
                 font-size: 2rem;
             }
         }
@@ -2577,12 +2577,12 @@ color: #2d3e40 !important;
             .product-primary-info h1 { font-size: 2rem; }
             .product-primary-info .breed-info { font-size: 1.1rem; }
             #nav-breedinfo .row.row-cols-lg-4 > .col { width: 100%; }
-            .dreamtails-difference-content h2 {
+            .happiness-is-pets-difference-content h2 {
                 font-size: 1.25rem;
                 flex-direction: column;
                 text-align: center;
             }
-            .dreamtails-difference-content h2 i {
+            .happiness-is-pets-difference-content h2 i {
                 margin-bottom: 0.5rem;
             }
         }

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -8,7 +8,7 @@
         <?php
         the_content();
         wp_link_pages( array(
-            'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'dreamtails' ),
+            'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'happiness-is-pets' ),
             'after'  => '</div>',
         ) );
         ?>

--- a/template-parts/page-header.php
+++ b/template-parts/page-header.php
@@ -23,7 +23,7 @@ if ( is_front_page() ) {
             </h1>
 
             <div class="breadcrumbs small">
-                <?php if ( function_exists( 'dreamtails_breadcrumb' ) ) { dreamtails_breadcrumb(); } ?>
+                <?php if ( function_exists( 'happiness_is_pets_breadcrumb' ) ) { happiness_is_pets_breadcrumb(); } ?>
             </div>
         </div>
     </div>

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -5,7 +5,7 @@
  * Displays WooCommerce content within the theme layout and
  * adds an optional sidebar on product category archives.
  *
- * @package Dream_Tails
+ * @package happiness-is-pets
  */
 
 get_header();
@@ -16,13 +16,13 @@ get_template_part( 'template-parts/page', 'header' );
         <div class="main-container">
             <?php if ( is_product_taxonomy() || is_shop() ) : ?>
                 <button class="btn filter-pets-btn" type="button" data-bs-toggle="offcanvas" data-bs-target="#petsFilterOffcanvas" aria-controls="petsFilterOffcanvas">
-                    <?php esc_html_e( 'Filter Pets', 'dreamtails' ); ?>
+                    <?php esc_html_e( 'Filter Pets', 'happiness-is-pets' ); ?>
                 </button>
 
                 <div class="offcanvas offcanvas-start pets-offcanvas" tabindex="-1" id="petsFilterOffcanvas" aria-labelledby="petsFilterLabel">
                     <div class="offcanvas-header">
-                        <h5 id="petsFilterLabel" class="offcanvas-title"><?php esc_html_e( 'Filter Pets', 'dreamtails' ); ?></h5>
-                        <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="<?php esc_attr_e( 'Close', 'dreamtails' ); ?>"></button>
+                        <h5 id="petsFilterLabel" class="offcanvas-title"><?php esc_html_e( 'Filter Pets', 'happiness-is-pets' ); ?></h5>
+                        <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="<?php esc_attr_e( 'Close', 'happiness-is-pets' ); ?>"></button>
                     </div>
                     <div class="offcanvas-body">
                         <?php get_sidebar( 'woocommerce-pets' ); ?>

--- a/woocommerce/archive-product.php
+++ b/woocommerce/archive-product.php
@@ -6,13 +6,13 @@ get_header( 'shop' );
 
 <?php if ( is_product_taxonomy() || is_shop() ) : ?>
     <button class="btn filter-pets-btn" type="button" data-bs-toggle="offcanvas" data-bs-target="#petsFilterOffcanvas" aria-controls="petsFilterOffcanvas">
-        <?php esc_html_e( 'Filter Pets', 'dreamtails' ); ?>
+        <?php esc_html_e( 'Filter Pets', 'happiness-is-pets' ); ?>
     </button>
 
     <div class="offcanvas offcanvas-start pets-offcanvas" tabindex="-1" id="petsFilterOffcanvas" aria-labelledby="petsFilterLabel">
         <div class="offcanvas-header">
-            <h5 id="petsFilterLabel" class="offcanvas-title"><?php esc_html_e( 'Filter Pets', 'dreamtails' ); ?></h5>
-            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="<?php esc_attr_e( 'Close', 'dreamtails' ); ?>"></button>
+            <h5 id="petsFilterLabel" class="offcanvas-title"><?php esc_html_e( 'Filter Pets', 'happiness-is-pets' ); ?></h5>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="<?php esc_attr_e( 'Close', 'happiness-is-pets' ); ?>"></button>
         </div>
         <div class="offcanvas-body">
             <?php get_sidebar( 'woocommerce-pets' ); ?>
@@ -26,7 +26,7 @@ get_header( 'shop' );
         <?php woocommerce_catalog_ordering(); ?>
     </div>
     <select class="product-filter form-select mb-3 d-block d-md-none">
-        <option value=""><?php esc_html_e( 'Filter Products', 'dreamtails' ); ?></option>
+        <option value=""><?php esc_html_e( 'Filter Products', 'happiness-is-pets' ); ?></option>
     </select>
 
     <?php woocommerce_product_loop_start(); ?>

--- a/woocommerce/content-product.php
+++ b/woocommerce/content-product.php
@@ -25,7 +25,7 @@ $reservation_url = get_theme_mod( 'header_book_button_url', '#' );
 ?>
 <div <?php wc_product_class( 'col' ); ?> >
     <div class="card pet-card shadow-sm border-0 rounded-3 overflow-hidden transition-hover h-100">
-        <a href="<?php the_permalink(); ?>" class="text-decoration-none position-relative" aria-label="<?php echo esc_attr( sprintf( __( 'View details for %s', 'dreamtails' ), get_the_title() ) ); ?>">
+        <a href="<?php the_permalink(); ?>" class="text-decoration-none position-relative" aria-label="<?php echo esc_attr( sprintf( __( 'View details for %s', 'happiness-is-pets' ), get_the_title() ) ); ?>">
             <div class="position-relative">
                 <?php if ( ! is_catalog_mode() ) : ?>
                 <!--div class="position-absolute top-0 end-0 m-2 z-index-1">
@@ -57,48 +57,48 @@ $reservation_url = get_theme_mod( 'header_book_button_url', '#' );
                         <?php endif; ?>
                     </div>
 
-                    <!-- <h5 class="card-title pet-name fw-bold mb-2"><?php //echo sprintf( esc_html__( 'Hi, my name is %s!', 'dreamtails' ), get_the_title() ); ?></h5> -->
-                    <h5 class="card-title pet-name fw-bold mb-2"><?php echo sprintf( esc_html__( '%s!', 'dreamtails' ), get_the_title() ); ?></h5>
+                    <!-- <h5 class="card-title pet-name fw-bold mb-2"><?php //echo sprintf( esc_html__( 'Hi, my name is %s!', 'happiness-is-pets' ), get_the_title() ); ?></h5> -->
+                    <h5 class="card-title pet-name fw-bold mb-2"><?php echo sprintf( esc_html__( '%s!', 'happiness-is-pets' ), get_the_title() ); ?></h5>
 
                     <div class="card-text">
                         <?php if ( $gender ) : ?>
                         <div class="pet-detail pet-gender d-flex align-items-center mb-1">
-                            <strong class="me-1"><?php esc_html_e( 'Gender:', 'dreamtails' ); ?></strong><span class="<?php echo esc_html($gender_class); ?>"> <?php echo esc_html( $gender ); ?></span>
+                            <strong class="me-1"><?php esc_html_e( 'Gender:', 'happiness-is-pets' ); ?></strong><span class="<?php echo esc_html($gender_class); ?>"> <?php echo esc_html( $gender ); ?></span>
                         </div>
                         <?php endif; ?>
 
                         <?php if ( $birth_date ) : ?>
                         <div class="pet-detail pet-dob d-flex align-items-center mb-1">
-                            <strong class="me-1"><?php esc_html_e( 'DOB:', 'dreamtails' ); ?></strong><span> <?php echo esc_html( $birth_date ); ?></span>
+                            <strong class="me-1"><?php esc_html_e( 'DOB:', 'happiness-is-pets' ); ?></strong><span> <?php echo esc_html( $birth_date ); ?></span>
                         </div>
                         <?php endif; ?>
 
                         <?php if ( $sku ) : ?>
                         <div class="pet-detail pet-ref d-flex align-items-center">
-                            <strong class="me-1"><?php esc_html_e( 'Ref:', 'dreamtails' ); ?></strong> <span class="ref-id badge bg-light text-dark">#<?php echo esc_html( $sku ); ?></span>
+                            <strong class="me-1"><?php esc_html_e( 'Ref:', 'happiness-is-pets' ); ?></strong> <span class="ref-id badge bg-light text-dark">#<?php echo esc_html( $sku ); ?></span>
                         </div>
                         <?php endif; ?>
                     </div>
                 </div>
 
                 <!-- <div class="col-auto d-flex flex-column align-items-stretch justify-content-center gap-2">
-                    <a href="tel:" class="btn btn-light btn-sm d-flex flex-column align-items-center gap-1 z-2 action-icon" title="<?php //esc_attr_e( 'Call Us', 'dreamtails' ); ?>">
+                    <a href="tel:" class="btn btn-light btn-sm d-flex flex-column align-items-center gap-1 z-2 action-icon" title="<?php //esc_attr_e( 'Call Us', 'happiness-is-pets' ); ?>">
                         <i class="fas fa-phone-alt"></i>
-                        <small><?php //esc_html_e( 'Call', 'dreamtails' ); ?></small>
+                        <small><?php //esc_html_e( 'Call', 'happiness-is-pets' ); ?></small>
                     </a>
 
-                    <a href="mailto:<?php //echo antispambot( get_option( 'admin_email' ) ); ?>" class="btn btn-dark btn-sm d-flex flex-column align-items-center gap-1 z-2 action-icon" title="<?php //esc_attr_e( 'Email Us', 'dreamtails' ); ?>">
+                    <a href="mailto:<?php //echo antispambot( get_option( 'admin_email' ) ); ?>" class="btn btn-dark btn-sm d-flex flex-column align-items-center gap-1 z-2 action-icon" title="<?php //esc_attr_e( 'Email Us', 'happiness-is-pets' ); ?>">
                         <i class="fas fa-envelope"></i>
-                        <small><?php //esc_html_e( 'Email', 'dreamtails' ); ?></small>
+                        <small><?php //esc_html_e( 'Email', 'happiness-is-pets' ); ?></small>
                     </a>
                 </div> -->
             </div>
         </div>
 
         <div class="card-footer bg-transparent border-top-0 text-center p-3">
-            <a href="<?php the_permalink(); ?>" class="btn btn-primary-theme w-100 mb-2"><?php esc_html_e( 'View Details', 'dreamtails' ); ?></a>
+            <a href="<?php the_permalink(); ?>" class="btn btn-primary-theme w-100 mb-2"><?php esc_html_e( 'View Details', 'happiness-is-pets' ); ?></a>
             <a href="<?php echo esc_url( $reservation_url ); ?>" class="btn btn-secondary-theme w-100 mb-2" style="background-color: var(--color-primary-dark-teal) !important; color: var(--color-button-text) !important;">
-                <?php esc_html_e( 'Make a Reservation', 'dreamtails' ); ?>
+                <?php esc_html_e( 'Make a Reservation', 'happiness-is-pets' ); ?>
             </a>
             <?php if ( $header_phone ) : ?>
             <a href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $header_phone ) ); ?>" class="btn btn-outline-primary-theme w-100"><i class="fas fa-phone me-1"></i> <?php echo esc_html( $header_phone ); ?></a>

--- a/woocommerce/content-single-product.php
+++ b/woocommerce/content-single-product.php
@@ -613,14 +613,14 @@ if ( 'Male' === $gender ) {
         </div>
     </div>
 
-    <!-- Dreamtails Difference Section -->
-    <div class="dreamtails-difference-section">
-        <div class="dreamtails-difference-content">
+    <!-- Happiness Is Pets Difference Section -->
+    <div class="happiness-is-pets-difference-section">
+        <div class="happiness-is-pets-difference-content">
             <div class="row align-items-center">
                 <div class="col-md-8">
                     <h2>
                         <i class="fas fa-star"></i>
-                        What's The Dreamtails Difference?
+                        What's The Happiness Is Pets Difference?
                     </h2>
                 </div>
                 <div class="col-md-4 text-md-end mt-3 mt-md-0">

--- a/woocommerce/emails/customer-completed-order.php
+++ b/woocommerce/emails/customer-completed-order.php
@@ -8,12 +8,12 @@ defined( 'ABSPATH' ) || exit;
 
  do_action( 'woocommerce_email_header', $email_heading, $email );
 ?>
-<p><?php esc_html_e( 'Hi there. Your recent order is now complete. Thank you for shopping with us!', 'dreamtails' ); ?></p>
+<p><?php esc_html_e( 'Hi there. Your recent order is now complete. Thank you for shopping with us!', 'happiness-is-pets' ); ?></p>
 <?php
   do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
   do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
   do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
-<p><?php esc_html_e( 'We hope to see you again soon.', 'dreamtails' ); ?></p>
+<p><?php esc_html_e( 'We hope to see you again soon.', 'happiness-is-pets' ); ?></p>
 <?php
 do_action( 'woocommerce_email_footer', $email );

--- a/woocommerce/myaccount/dashboard.php
+++ b/woocommerce/myaccount/dashboard.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || exit;
   wc_print_notices();
   /** @var WP_User $current_user */
   $current_user = wp_get_current_user();
-  printf( __( 'Hello %1$s', 'dreamtails' ), '<strong>' . esc_html( $current_user->display_name ) . '</strong>' );
+  printf( __( 'Hello %1$s', 'happiness-is-pets' ), '<strong>' . esc_html( $current_user->display_name ) . '</strong>' );
   ?>
 </p>
 <?php do_action( 'woocommerce_account_dashboard' ); ?>


### PR DESCRIPTION
## Summary
- Rebrand theme from DreamTails to Happiness Is Pets
- Update text domain, function prefixes, and asset handles
- Refresh default content and settings to reflect new name

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689c1031cadc8326bf0ded16bfd616d4