### PR TITLE
Set hero height to 700px

### DIFF
--- a/style.css
+++ b/style.css
@@ -665,7 +665,7 @@ a:hover {
 /* --- Front Page Specific Styles --- */
 .front-page-hero {
     background-color: var(--color-secondary-light-pink);
-    min-height: 60vh;
+    height: 700px;
     display: flex;
     align-items: center;
     overflow: visible; /* allow hero image to overlap */


### PR DESCRIPTION
## Summary
- set front page hero section height to a fixed 700px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c10c751b48326857a30f44ca2a2ba