### PR TITLE
Standardize h2 styling and convert financing links to buttons

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -188,10 +188,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
                                             <p>Quick and easy financing is available. Apply Now!</p>
                                         </div>
                                         <div class="info-layout-action d-flex btn-flex">
-                                            <a style="white-space:nowrap" class="mt-1 F2 sw-100" href="https://app.formpiper.com/outside-form/happiness-is-pets-schererville/fTlGP4zm9zLqayP9FI9M1nB4JACHgY?qr=true" target="_blank">
+                                            <a style="white-space:nowrap" class="theme-primary-btn mt-1 sw-100" href="https://app.formpiper.com/outside-form/happiness-is-pets-schererville/fTlGP4zm9zLqayP9FI9M1nB4JACHgY?qr=true" target="_blank">
                                                 Apply Now - Schereville
                                             </a>
-                                            <a style="white-space:nowrap" class="mt-1 F2 sw-100" href="https://app.formpiper.com/outside-form/happiness-is-pets-indianapolis/tjtpqDXcm2p4H4oOd37nKRsg5xFwGa" target="_blank">
+                                            <a style="white-space:nowrap" class="theme-primary-btn mt-1 sw-100" href="https://app.formpiper.com/outside-form/happiness-is-pets-indianapolis/tjtpqDXcm2p4H4oOd37nKRsg5xFwGa" target="_blank">
                                                 Apply Now - Indianapolis
                                             </a>
                                         </div>

--- a/style.css
+++ b/style.css
@@ -85,6 +85,14 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     font-weight: 700;
 }
 
+h2 {
+    font-style: normal;
+    font-weight: 700;
+    line-height: 125%;
+    font-size: 40px;
+    text-transform: capitalize;
+}
+
 /* Link styling */
 a {
     color: var(--color-link);


### PR DESCRIPTION
## Summary
- Apply consistent styling to all `h2` headings
- Convert financing links on homepage to themed buttons

## Testing
- `php -l front-page.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2637fd4483268556e3f2b117791f