### PR TITLE
Polish CTAs and footer styling

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -86,7 +86,7 @@
                     <div class="col-sm-6 text-sm-end">
                         <ul class="footer-bottom-links">
                             <li><a href="/privacy-policy">Privacy Policy</a></li>
-                            <li><a href="/terms-of-use">Terms of Use</a></li>
+                            <li><a href="/contact/">Contact</a></li>
                         </ul>
                     </div>
                 </div>

--- a/front-page.php
+++ b/front-page.php
@@ -232,6 +232,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
                             <p class="primary1-bold"><?php esc_html_e( '7 day veterinary check', 'happiness-is-pets' ); ?></p>
                             <p><?php esc_html_e( 'Bring your new puppy to any of our in-network clinics within 7 days of purchase for a complimentary wellness check-up.', 'happiness-is-pets' ); ?></p>
                         </div>
+                        <a href="/veterinary-check/" class="theme-primary-btn" style="display: block; width: fit-content; "><?php esc_html_e( 'Veterinary Check', 'happiness-is-pets' ); ?></a>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -2844,9 +2844,13 @@ body .product-primary-info h1.product_title {
 .cssFooter .footer-menu li a {
     font-size: 15px;
     line-height: 1.8;
-    color: rgba(255,255,255,0.9);
+    color: #FFFFFF;
 }
-.cssFooter .footer-menu li a:hover {
+.cssFooter a {
+    color: #FFFFFF;
+    text-decoration: none;
+}
+.cssFooter a:hover {
     color: #FFFFFF;
     text-decoration: underline;
 }
@@ -2859,10 +2863,26 @@ body .product-primary-info h1.product_title {
 .cssFooter .footer-bottom p,
 .cssFooter .footer-bottom a {
     font-size: 14px;
-    color: rgba(255,255,255,0.9);
-}
-.cssFooter .footer-bottom a:hover {
     color: #FFFFFF;
+}
+
+.btn-flex {
+    gap: 15px;
+}
+
+.infofirst-img {
+    border-radius: 50%;
+    border: 4px solid var(--color-footer-bg);
+    object-fit: cover;
+}
+
+.cssFooter .footer-bottom-links {
+    list-style: none;
+    display: flex;
+    gap: 15px;
+    justify-content: flex-end;
+    padding: 0;
+    margin: 0;
 }
 
 /* Responsive Breakpoints */


### PR DESCRIPTION
## Summary
- Add veterinary check CTA and space out financing buttons on front page
- Style footer links in white with flex layout and Contact link
- Make "Take Home" image circular for a polished hero section

## Testing
- `php -l front-page.php`
- `php -l footer.php`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e28f3a408832696dbcdb56e9c0bd2