### PR TITLE
Improve header contact and pagination styling

### DIFF
--- a/header.php
+++ b/header.php
@@ -104,13 +104,15 @@
                 <?php // Right side: Contact info and CTA button ?>
                 <div class="header-top-button ms-auto">
                     <div class="header-contact d-flex align-items-center justify-content-end">
-                        <?php
-                        $phone = get_theme_mod( 'header_phone_number', '941-203-1196' );
-                        if ( $phone ) : ?>
-                            <a class="header-phone-number me-3" href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>" aria-label="<?php echo esc_attr( $phone ); ?>">
-                                <i class="fas fa-phone me-2 header-icon"></i><span class="phone-text d-none d-md-inline"><?php echo esc_html( $phone ); ?></span>
+                        <div class="dropdown header-phone-dropdown me-3">
+                            <a class="header-icon dropdown-toggle" href="#" id="headerPhoneDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="<?php esc_attr_e( 'Call Us', 'happiness-is-pets' ); ?>">
+                                <i class="fas fa-phone"></i>
                             </a>
-                        <?php endif; ?>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="headerPhoneDropdown">
+                                <li><a class="dropdown-item" href="tel:317-537-2480"><?php esc_html_e( 'Indianapolis: 317-537-2480', 'happiness-is-pets' ); ?></a></li>
+                                <li><a class="dropdown-item" href="tel:219-865-3078"><?php esc_html_e( 'Schererville: 219-865-3078', 'happiness-is-pets' ); ?></a></li>
+                            </ul>
+                        </div>
                         <a href="<?php echo esc_url( function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : '#' ); ?>" class="header-icon header-account-icon me-3" aria-label="<?php esc_attr_e( 'My Account', 'happiness-is-pets' ); ?>">
                             <i class="fas fa-user"></i>
                         </a>

--- a/style.css
+++ b/style.css
@@ -215,6 +215,22 @@ input[type="reset"]:hover,
     margin-left: 0.5rem;
 }
 
+.header-phone-dropdown .dropdown-toggle::after {
+    display: none;
+}
+.header-phone-dropdown .dropdown-menu {
+    min-width: 12rem;
+    padding: 0.5rem 0;
+}
+.header-phone-dropdown .dropdown-item {
+    color: var(--color-primary-dark-teal);
+    font-family: var(--font-primary);
+}
+.header-phone-dropdown .dropdown-item:hover {
+    background-color: var(--color-primary-dark-teal);
+    color: #fff;
+}
+
 
 .header-contact {
     margin-bottom: 0.25rem;
@@ -2032,6 +2048,32 @@ button#rmp_menu_trigger-166.is-active {
 .product-page-wrapper { padding-top: 1.5rem !important; }
 .woocommerce-breadcrumb { font-size: 0.875rem !important; padding-bottom: 0px !important; margin-bottom: 1rem !important; margin-top: 0px !important; }
 
+/* WooCommerce Pagination */
+.woocommerce nav.woocommerce-pagination {
+    margin-top: 2rem;
+    text-align: center;
+}
+.woocommerce nav.woocommerce-pagination ul {
+    display: inline-flex;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.woocommerce nav.woocommerce-pagination ul li a,
+.woocommerce nav.woocommerce-pagination ul li span {
+    display: block;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-primary-dark-teal);
+    color: var(--color-primary-dark-teal);
+    border-radius: 0.25rem;
+}
+.woocommerce nav.woocommerce-pagination ul li a:hover,
+.woocommerce nav.woocommerce-pagination ul li span.current {
+    background-color: var(--color-primary-dark-teal);
+    color: #fff;
+}
+
 /* Apply theme fonts */
 body .product-primary-info h1.product_title {
     font-family: var(--font-secondary) !important;
@@ -2858,7 +2900,7 @@ body .product-primary-info h1.product_title {
     background: #00c8ba;
     padding: 20px 0;
     border-top: 1px solid rgba(255,255,255,0.1);
-    text-align: center;
+    text-align: left;
 }
 .cssFooter .footer-bottom p,
 .cssFooter .footer-bottom a {


### PR DESCRIPTION
## Summary
- replace header phone number with dropdown phone icon for multiple locations
- style WooCommerce pagination with spacing and theme colors
- left-align footer copyright section

## Testing
- `php -l header.php footer.php`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e36874fb8832694edc65ca5b2916a