### PR TITLE
Use icon for header phone link

### DIFF
--- a/header.php
+++ b/header.php
@@ -107,8 +107,8 @@
                         <?php
                         $phone = get_theme_mod( 'header_phone_number', '941-203-1196' );
                         if ( $phone ) : ?>
-                            <a class="header-phone-number me-3" href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>" aria-label="<?php echo esc_attr( $phone ); ?>">
-                                <i class="fas fa-phone me-2 header-icon"></i><span class="phone-text d-none d-md-inline"><?php echo esc_html( $phone ); ?></span>
+                            <a class="header-icon header-phone-icon me-3" href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>" aria-label="<?php echo esc_attr( $phone ); ?>">
+                                <i class="fas fa-phone"></i>
                             </a>
                         <?php endif; ?>
                         <a href="<?php echo esc_url( function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : '#' ); ?>" class="header-icon header-account-icon me-3" aria-label="<?php esc_attr_e( 'My Account', 'happiness-is-pets' ); ?>">

--- a/style.css
+++ b/style.css
@@ -185,21 +185,7 @@ input[type="reset"]:hover,
     opacity: 0.9;
 }
 
-/* Phone number displayed in the top header bar */
-.header-phone-number {
-    color: #000;
-    font-weight: bold;
-    white-space: nowrap;
-    font-size: 1.25rem;
-    display: flex;
-    align-items: center;
-    text-decoration: none;
-    font-family: var(--font-primary);
-}
-.header-phone-number i {
-    font-size: 1.25rem;
-}
-
+/* Header icons */
 .header-icon {
     color: var(--color-primary-dark-teal);
     text-decoration: none;


### PR DESCRIPTION
## Summary
- Show only a phone icon in the header contact area
- Remove phone-number specific styling so the icon uses standard header icon color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e3f296728832694f30b57b67831c0