### PR TITLE
Refine homepage customizer and hero options

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -20,16 +20,27 @@ get_header();
             </div>
             <div class="container">
                 <div class="row align-items-center">
-                    <div class="col-12 col-md-6 p-0 hero-image mb-4 mb-md-0" style="background-image: url('<?php echo esc_url( get_theme_mod( 'hero_image', get_template_directory_uri() . '/assets/images/homepage_hero.png' ) ); ?>');"></div>
+                    <?php $hero_image = get_theme_mod( 'hero_image' ); ?>
+                    <div class="col-12 col-md-6 p-0 hero-image mb-4 mb-md-0"<?php if ( $hero_image ) : ?> style="background-image: url('<?php echo esc_url( $hero_image ); ?>');"<?php endif; ?>></div>
                     <div class="col-md-6">
                         <div class="hero-content p-4 p-md-5 rounded text-center">
-                            <h1 class="display-4 fw-bold mb-3" style="color: var(--color-primary-dark-teal); font-size: 2rem;">
-                                <?php echo esc_html( get_theme_mod( 'hero_heading', 'Meet Your New Best Friend' ) ); ?>
-                            </h1>
-                            <p class="lead mb-4"><?php echo esc_html( get_theme_mod( 'hero_text', 'Stop by either of our locations to meet our adorable puppies in person. Our friendly team is ready to help you find the perfect match and guide you through bringing home a healthy, happy companion today!' ) ); ?></p>
-                            <a href="<?php echo esc_url( get_theme_mod( 'hero_button_url', '#available-puppies' ) ); ?>" class="theme-primary-btn mt-2">
-                                <?php echo esc_html( get_theme_mod( 'hero_button_text', 'Available Puppies' ) ); ?>
-                            </a>
+                            <?php if ( $hero_heading = get_theme_mod( 'hero_heading' ) ) : ?>
+                                <h1 class="display-4 fw-bold mb-3" style="color: var(--color-primary-dark-teal); font-size: 2rem;">
+                                    <?php echo esc_html( $hero_heading ); ?>
+                                </h1>
+                            <?php endif; ?>
+                            <?php if ( $hero_text = get_theme_mod( 'hero_text' ) ) : ?>
+                                <p class="lead mb-4"><?php echo esc_html( $hero_text ); ?></p>
+                            <?php endif; ?>
+                            <?php
+                            $hero_button_text = get_theme_mod( 'hero_button_text' );
+                            $hero_button_url  = get_theme_mod( 'hero_button_url' );
+                            if ( $hero_button_text && $hero_button_url ) :
+                            ?>
+                                <a href="<?php echo esc_url( $hero_button_url ); ?>" class="theme-primary-btn mt-2">
+                                    <?php echo esc_html( $hero_button_text ); ?>
+                                </a>
+                            <?php endif; ?>
                         </div>
                     </div>
                 </div>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -7,6 +7,9 @@
 
 function happiness_is_pets_customize_register( $wp_customize ) {
 
+    // Remove duplicate default WordPress Homepage Settings section.
+    $wp_customize->remove_section( 'static_front_page' );
+
     // =========================================
     // HEADER SETTINGS PANEL
     // =========================================
@@ -202,7 +205,6 @@ function happiness_is_pets_customize_register( $wp_customize ) {
     ) );
 
     $wp_customize->add_setting( 'hero_heading', array(
-            'default'           => 'Meet Your New Best Friend',
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'hero_heading', array(
@@ -212,7 +214,6 @@ function happiness_is_pets_customize_register( $wp_customize ) {
     ) );
 
     $wp_customize->add_setting( 'hero_text', array(
-            'default'           => 'Stop by either of our locations to meet our adorable puppies in person. Our friendly team is ready to help you find the perfect match and guide you through bringing home a healthy, happy companion today!',
             'sanitize_callback' => 'sanitize_textarea_field',
     ) );
     $wp_customize->add_control( 'hero_text', array(
@@ -222,7 +223,6 @@ function happiness_is_pets_customize_register( $wp_customize ) {
     ) );
 
     $wp_customize->add_setting( 'hero_button_text', array(
-            'default'           => 'Available Puppies',
             'sanitize_callback' => 'sanitize_text_field',
     ) );
     $wp_customize->add_control( 'hero_button_text', array(
@@ -232,7 +232,6 @@ function happiness_is_pets_customize_register( $wp_customize ) {
     ) );
 
     $wp_customize->add_setting( 'hero_button_url', array(
-            'default'           => '#available-puppies',
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( 'hero_button_url', array(
@@ -242,7 +241,6 @@ function happiness_is_pets_customize_register( $wp_customize ) {
     ) );
 
     $wp_customize->add_setting( 'hero_image', array(
-            'default'           => get_template_directory_uri() . '/assets/images/homepage_hero.png',
             'sanitize_callback' => 'esc_url_raw',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'hero_image', array(
@@ -251,11 +249,18 @@ function happiness_is_pets_customize_register( $wp_customize ) {
     ) ) );
 
     $wp_customize->add_setting( 'hero_background_color', array(
-            'default'           => '#FFD6D4',
             'sanitize_callback' => 'sanitize_hex_color',
     ) );
     $wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'hero_background_color', array(
             'label'   => __( 'Hero Background Color', 'happiness-is-pets' ),
+            'section' => 'homepage_hero',
+    ) ) );
+
+    $wp_customize->add_setting( 'hero_background_image', array(
+            'sanitize_callback' => 'esc_url_raw',
+    ) );
+    $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'hero_background_image', array(
+            'label'   => __( 'Hero Background Image', 'happiness-is-pets' ),
             'section' => 'homepage_hero',
     ) ) );
 
@@ -834,9 +839,20 @@ function happiness_is_pets_customizer_css() {
         }
 
         /* Hero Section */
+        <?php
+        $hero_bg_color = get_theme_mod( 'hero_background_color' );
+        $hero_bg_image = get_theme_mod( 'hero_background_image' );
+        if ( $hero_bg_color || $hero_bg_image ) :
+        ?>
         .front-page-hero {
-            background-color: <?php echo esc_attr( get_theme_mod( 'hero_background_color', '#FFD6D4' ) ); ?>;
+            <?php if ( $hero_bg_color ) : ?>
+            background-color: <?php echo esc_attr( $hero_bg_color ); ?>;
+            <?php endif; ?>
+            <?php if ( $hero_bg_image ) : ?>
+            background-image: url('<?php echo esc_url( $hero_bg_image ); ?>');
+            <?php endif; ?>
         }
+        <?php endif; ?>
 
         /* Available Puppies Section */
         #available-puppies {


### PR DESCRIPTION
## Summary
- remove duplicate Homepage Settings section in the Customizer
- add hero background image option and drop default hero values
- render hero content conditionally based on customizer entries

## Testing
- `php -l inc/customizer.php`
- `php -l front-page.php`


------
https://chatgpt.com/codex/tasks/task_e_689e71089f788326962fb257260e5650