### PR TITLE
Refine phone dropdown styling

### DIFF
--- a/header.php
+++ b/header.php
@@ -104,10 +104,10 @@ $locations = happiness_is_pets_get_locations();
                 <div class="header-top-button ms-auto">
                     <div class="header-contact d-flex align-items-center justify-content-end">
                         <?php if ( ! empty( $locations ) ) : ?>
-                            <div class="dropdown me-3">
-                                <button class="header-icon header-phone-icon dropdown-toggle" type="button" id="headerPhoneDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                            <div class="dropdown">
+                                <a class="header-icon header-phone-icon me-3" href="#" role="button" id="headerPhoneDropdown" data-bs-toggle="dropdown" aria-expanded="false">
                                     <i class="fas fa-phone"></i>
-                                </button>
+                                </a>
                                 <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="headerPhoneDropdown">
                                     <?php foreach ( $locations as $loc ) :
                                         if ( ! empty( $loc['phone'] ) ) :

--- a/style.css
+++ b/style.css
@@ -47,11 +47,6 @@ Text Domain: happiness-is-pets
 }
 
 
-/* Hide dropdown arrow on header phone icon */
-.header-phone-icon.dropdown-toggle::after {
-    display: none;
-}
-
 /* WooCommerce Blocks (Cart & Checkout) */
 .wp-block-woocommerce-cart,
 .wp-block-woocommerce-checkout {


### PR DESCRIPTION
## Summary
- keep header phone icon styled as before while triggering location dropdown
- remove unused arrow-hiding CSS for phone icon

## Testing
- `npm test` *(fails: could not read package.json)*
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_689e75099780832687d6ab6856fc0745