### PR TITLE
Improve mobile navigation, hero image, sliders, and footer

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -20,8 +20,20 @@ get_header();
             </div>
             <div class="container">
                 <div class="row align-items-center">
-                    <?php $hero_image = get_theme_mod( 'hero_image' ); ?>
+                    <?php
+                    $hero_image        = get_theme_mod( 'hero_image' );
+                    $hero_image_mobile = get_theme_mod( 'hero_image_mobile' );
+                    ?>
                     <div class="col-12 col-md-6 p-0 hero-image mb-4 mb-md-0"<?php if ( $hero_image ) : ?> style="background-image: url('<?php echo esc_url( $hero_image ); ?>');"<?php endif; ?>></div>
+                    <?php if ( $hero_image_mobile ) : ?>
+                        <style>
+                            @media (max-width: 767px) {
+                                .front-page-hero .hero-image {
+                                    background-image: url('<?php echo esc_url( $hero_image_mobile ); ?>') !important;
+                                }
+                            }
+                        </style>
+                    <?php endif; ?>
                     <div class="col-md-6">
                         <div class="hero-content p-4 p-md-5 rounded text-center">
                             <?php if ( $hero_heading = get_theme_mod( 'hero_heading' ) ) : ?>
@@ -144,11 +156,24 @@ get_header();
                         prevEl: '.available-puppies-swiper .swiper-button-prev',
                     },
                     breakpoints: {
-                        0: { slidesPerView: 1 },
-                        576: { slidesPerView: 2 },
-                        768: { slidesPerView: 3 },
-                        992: { slidesPerView: 4 },
+                        0: { slidesPerView: 2 },
+                        576: { slidesPerView: 3 },
+                        768: { slidesPerView: 4 },
+                        992: { slidesPerView: 5 },
                         1200: { slidesPerView: 6 },
+                    },
+                } );
+                new Swiper( '.reviews-swiper', {
+                    slidesPerView: 3,
+                    spaceBetween: 20,
+                    navigation: {
+                        nextEl: '.reviews-swiper .swiper-button-next',
+                        prevEl: '.reviews-swiper .swiper-button-prev',
+                    },
+                    breakpoints: {
+                        0: { slidesPerView: 1.2 },
+                        768: { slidesPerView: 2 },
+                        992: { slidesPerView: 3 },
                     },
                 } );
             } );
@@ -275,18 +300,22 @@ get_header();
                                     ),
                             );
                             ?>
-                            <div class="row justify-content-center">
-                                <?php foreach ( $reviews as $review ) : ?>
-                                    <div class="col-md-4 mb-4">
-                                        <div class="carousel-item-box carousel-item-box-style-6 h-100">
-                                            <div class="carousel-item-box-desc mx-4">
-                                                <div class="carousel-item-box-desc-title"><?php echo esc_html( $review['title'] ); ?></div>
-                                                <div class="carousel-item-box-desc-desc"><?php echo esc_html( $review['text'] ); ?></div>
-                                                <div class="carousel-item-box-desc-auth">- <?php echo esc_html( $review['author'] ); ?></div>
+                            <div class="swiper reviews-swiper">
+                                <div class="swiper-wrapper">
+                                    <?php foreach ( $reviews as $review ) : ?>
+                                        <div class="swiper-slide">
+                                            <div class="carousel-item-box carousel-item-box-style-6 h-100">
+                                                <div class="carousel-item-box-desc mx-4">
+                                                    <div class="carousel-item-box-desc-title"><?php echo esc_html( $review['title'] ); ?></div>
+                                                    <div class="carousel-item-box-desc-desc"><?php echo esc_html( $review['text'] ); ?></div>
+                                                    <div class="carousel-item-box-desc-auth">- <?php echo esc_html( $review['author'] ); ?></div>
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                <?php endforeach; ?>
+                                    <?php endforeach; ?>
+                                </div>
+                                <div class="swiper-button-next"></div>
+                                <div class="swiper-button-prev"></div>
                             </div>
                             <div class="carousel-layout-wrap-footer text-center pt-3">
                                 <a href="<?php echo esc_url( get_theme_mod( 'reviews_button_url', '/testimonials/' ) ); ?>" class="mt-2 theme-primary-btn">

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -234,6 +234,14 @@ function happiness_is_pets_customize_register( $wp_customize ) {
             'section' => 'homepage_hero',
     ) ) );
 
+    $wp_customize->add_setting( 'hero_image_mobile', array(
+            'sanitize_callback' => 'esc_url_raw',
+    ) );
+    $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'hero_image_mobile', array(
+            'label'   => __( 'Hero Mobile Image', 'happiness-is-pets' ),
+            'section' => 'homepage_hero',
+    ) ) );
+
     $wp_customize->add_setting( 'hero_background_color', array(
             'sanitize_callback' => 'sanitize_hex_color',
     ) );

--- a/style.css
+++ b/style.css
@@ -350,12 +350,13 @@ input[type="reset"]:hover,
 .happiness-is-pets-offcanvas .offcanvas-header {
     background-color: var(--color-primary-light-blue-grey);
     padding: 1.5rem;
-    border-bottom: 3px solid var(--color-secondary-light-pink);
+    border-bottom: 3px solid var(--color-primary-dark-teal);
 }
 
 .happiness-is-pets-offcanvas .offcanvas-logo img {
     max-height: 60px;
     width: auto;
+    max-width: 100%;
 }
 
 .happiness-is-pets-offcanvas .happiness-is-pets-close {
@@ -411,7 +412,7 @@ input[type="reset"]:hover,
 
 .mobile-menu-list a:hover,
 .mobile-menu-list .current-menu-item > a {
-    background-color: var(--color-secondary-light-pink);
+    background-color: var(--color-primary-light-blue-grey);
     padding-left: 2rem;
     color: var(--color-primary-dark-teal);
 }
@@ -469,7 +470,7 @@ input[type="reset"]:hover,
     flex-direction: column;
     align-items: center;
     padding: 1rem;
-    background-color: #ffd0cd;
+    background-color: var(--color-primary-light-blue-grey);
     border-radius: 10px;
     transition: transform 0.3s ease, background-color 0.3s ease;
     text-align: center;
@@ -477,7 +478,7 @@ input[type="reset"]:hover,
 
 .quick-link-item:hover {
     transform: translateY(-3px);
-    background-color: #e1b8b5;
+    background-color: var(--color-secondary-light-beige);
 }
 
 .quick-link-item i {
@@ -541,7 +542,7 @@ input[type="reset"]:hover,
     justify-content: center;
     width: 40px;
     height: 40px;
-    background-color: var(--color-secondary-light-pink);
+    background-color: var(--color-primary-light-blue-grey);
     color: var(--color-primary-dark-teal);
     border-radius: 50%;
     transition: transform 0.3s ease, background-color 0.3s ease;
@@ -560,7 +561,7 @@ input[type="reset"]:hover,
 /* Mobile CTA Button */
 .mobile-cta-button {
     padding: 1.5rem;
-    background-color: rgba(255, 207, 205, 0.2);
+    background-color: rgba(188, 201, 197, 0.2);
     margin-top: auto;
 }
 
@@ -2837,6 +2838,14 @@ body .product-primary-info h1.product_title {
     margin-bottom: 25px;
     text-transform: none;
 }
+.cssFooter .footer-contact-list,
+.cssFooter .footer-hours-list,
+.cssFooter .footer-menu,
+.cssFooter .footer-bottom-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
 .cssFooter .footer-contact-list li,
 .cssFooter .footer-hours-list li,
 .cssFooter .footer-menu li a {
@@ -2890,6 +2899,22 @@ body .product-primary-info h1.product_title {
     margin: 0;
 }
 
+@media (max-width: 767px) {
+    .cssFooter .logo-section,
+    .cssFooter .contact-section,
+    .cssFooter .hours-section,
+    .cssFooter .links-section {
+        text-align: center;
+    }
+    .cssFooter .footer-bottom p,
+    .cssFooter .footer-bottom a {
+        text-align: center;
+    }
+    .cssFooter .footer-bottom-links {
+        justify-content: center;
+    }
+}
+
 /* Responsive Breakpoints */
 @media (max-width: 1199px) {
     .cssHeader { padding: 0 30px; }
@@ -2910,7 +2935,7 @@ body .product-primary-info h1.product_title {
     .theme-primary-btn,
     #our-guarantee .theme-primary-btn,
     #reviews .theme-primary-btn { width: 100%; }
-    .available-puppies-swiper .swiper-slide { width: 100%; height: auto; }
+    .available-puppies-swiper .swiper-slide { height: auto; }
     .available-puppies-swiper .swiper-slide img { width: 100%; height: auto; }
 }
 


### PR DESCRIPTION
## Summary
- style off-canvas menu using theme colors and ensure logo fits
- add mobile hero image option and show on small screens
- adjust puppy and review sections to horizontal swipers on mobile
- center and clean up footer lists on mobile

## Testing
- `php -l inc/customizer.php front-page.php`


------
https://chatgpt.com/codex/tasks/task_e_689e830d69f48326881ba967856cbf24