### PR TITLE
Add default mobile hero background image

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -252,6 +252,7 @@ function happiness_is_pets_customize_register( $wp_customize ) {
 
     $wp_customize->add_setting( 'hero_background_image', array(
             'sanitize_callback' => 'esc_url_raw',
+            'default'           => get_template_directory_uri() . '/assets/images/hero.jpg',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'hero_background_image', array(
             'label'   => __( 'Hero Background Image', 'happiness-is-pets' ),
@@ -260,6 +261,7 @@ function happiness_is_pets_customize_register( $wp_customize ) {
 
     $wp_customize->add_setting( 'hero_background_image_mobile', array(
             'sanitize_callback' => 'esc_url_raw',
+            'default'           => get_template_directory_uri() . '/assets/images/hero-mobile.jpg',
     ) );
     $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'hero_background_image_mobile', array(
             'label'   => __( 'Hero Background Image (Mobile)', 'happiness-is-pets' ),


### PR DESCRIPTION
## Summary
- Provide default hero background image paths for desktop and mobile via Customizer settings

## Testing
- `php -l inc/customizer.php`
- `npm test` *(fails: package.json not found)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689e8bf66c3c832697f0717a5c295240