### PR TITLE
Remove excessive padding from subpage titles

### DIFF
--- a/template-parts/page-header.php
+++ b/template-parts/page-header.php
@@ -4,7 +4,7 @@ if ( is_front_page() ) {
 }
 ?>
 <div class="header-title">
-    <div class="page-header-bar py-4">
+    <div class="page-header-bar">
         <div class="main-container">
             <h1 class="page-title mb-1">
                 <?php


### PR DESCRIPTION
## Summary
- Remove `py-4` class from page header bar to eliminate unwanted padding on subpages

## Testing
- `php -l template-parts/page-header.php`


------
https://chatgpt.com/codex/tasks/task_e_689e8e3215e483269a7827f95885e72c