### PR TITLE
Simplify mobile offcanvas menu styling

### DIFF
--- a/header.php
+++ b/header.php
@@ -136,17 +136,6 @@ $locations = happiness_is_pets_get_locations();
         <?php // --- Offcanvas Menu (Triggered by hamburger in top bar) --- ?>
         <div class="offcanvas offcanvas-start happiness-is-pets-offcanvas" tabindex="-1" id="mobileNavOffcanvas" aria-labelledby="mobileNavOffcanvasLabel">
             <div class="offcanvas-header">
-                <div class="offcanvas-logo">
-                    <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-                        <?php
-                        if ( function_exists( 'the_custom_logo' ) && has_custom_logo() ) {
-                            the_custom_logo();
-                        } else {
-                            ?>
-                            <img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/logo_horizontal.png' ); ?>" alt="<?php bloginfo( 'name' ); ?>">
-                        <?php } ?>
-                    </a>
-                </div>
                 <button type="button" class="btn-close happiness-is-pets-close" data-bs-dismiss="offcanvas" aria-label="<?php esc_attr_e( 'Close', 'happiness-is-pets' ); ?>"></button>
             </div>
             <div class="offcanvas-body">

--- a/style.css
+++ b/style.css
@@ -252,13 +252,16 @@ input[type="reset"]:hover,
     align-items: center;
     justify-content: center;
     transition: background-color 0.3s ease;
+    border: none;
+    background: none;
 }
 
 .happiness-is-pets-toggler:hover,
 .happiness-is-pets-toggler:focus {
-    background-color: rgba(61, 81, 85, 0.05);
+    background-color: transparent;
     outline: none;
     box-shadow: none;
+    border: none;
 }
 
 .happiness-is-pets-toggler .navbar-toggler-icon {
@@ -348,15 +351,10 @@ input[type="reset"]:hover,
 }
 
 .happiness-is-pets-offcanvas .offcanvas-header {
-    background-color: var(--color-primary-light-blue-grey);
     padding: 1.5rem;
-    border-bottom: 3px solid var(--color-primary-dark-teal);
-}
-
-.happiness-is-pets-offcanvas .offcanvas-logo img {
-    max-height: 60px;
-    width: auto;
-    max-width: 100%;
+    background-color: transparent;
+    border-bottom: none;
+    justify-content: flex-end;
 }
 
 .happiness-is-pets-offcanvas .happiness-is-pets-close {


### PR DESCRIPTION
## Summary
- Remove logo from mobile offcanvas menu
- Make offcanvas header transparent with no border and align close button right
- Strip border and background from hamburger toggle button

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_689e9b89603c83268a99dd28626bfc9f